### PR TITLE
Improving messaging in scenario runs

### DIFF
--- a/scenario_lab/interfaces/cli.py
+++ b/scenario_lab/interfaces/cli.py
@@ -47,7 +47,9 @@ def cli(verbose: bool) -> None:
         scenario-lab estimate scenarios/ai-summit
     """
     # Configure logging
-    level = logging.DEBUG if verbose else logging.INFO
+    # Default to WARNING to show only user-friendly messages (not INFO/DEBUG)
+    # Use --verbose to see full technical logging
+    level = logging.DEBUG if verbose else logging.WARNING
     logging.basicConfig(
         level=level,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",


### PR DESCRIPTION
Addresses issue #20 by changing the default logging level from INFO to WARNING. This suppresses technical logging (timestamps, module names, INFO-level logs) by default, showing only user-friendly messages and warnings/errors.

Users can still see full technical logging with the --verbose flag.

Changes:
- Default logging level: INFO → WARNING
- Added explanatory comments
- Maintains --verbose flag for DEBUG-level logging

Result: Cleaner CLI output with less cognitive load, while preserving debugging capabilities when needed.