### PR TITLE
Fix CLI logging: keep INFO level but simplify format

### DIFF
--- a/scenario_lab/interfaces/cli.py
+++ b/scenario_lab/interfaces/cli.py
@@ -47,12 +47,13 @@ def cli(verbose: bool) -> None:
         scenario-lab estimate scenarios/ai-summit
     """
     # Configure logging
-    # Default to WARNING to show only user-friendly messages (not INFO/DEBUG)
-    # Use --verbose to see full technical logging
-    level = logging.DEBUG if verbose else logging.WARNING
+    # Default: INFO level with clean format (no timestamps/module names)
+    # Verbose: DEBUG level with full technical details
+    level = logging.DEBUG if verbose else logging.INFO
+    format_str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s" if verbose else "%(message)s"
     logging.basicConfig(
         level=level,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        format=format_str,
     )
 
 


### PR DESCRIPTION
Changes default logging to show INFO messages in clean format without timestamps and module names, while preserving full technical logging with --verbose flag.

Default behavior:
- Level: INFO (shows progress messages)
- Format: Clean text only (no timestamps/module names)
- Example: "Setting up runner..." instead of "2025-11-21 08:33:35,384 - scenario_lab.runners.sync_runner - INFO - Setting up runner..."

With --verbose flag:
- Level: DEBUG (full technical detail)
- Format: Timestamps, module names, log levels
- For debugging and troubleshooting

This provides better balance between visibility and readability.