### PR TITLE
Fix --end-turn to correctly execute N actor turns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ The framework supports stopping and resuming scenario runs, crucial for handling
 - State includes: world state, actor states, costs, metrics, execution metadata
 
 **Command-line arguments:**
-- `--end-turn N` - Stop at turn N (e.g., --end-turn 5 stops after turn 5)
+- `--end-turn N` - Execute N turns (e.g., --end-turn 5 runs 5 actor decision rounds)
 - `--credit-limit X` - Halt if cost exceeds $X
 - `--resume <path>` - Resume from halted run
 

--- a/scenario_lab/core/orchestrator.py
+++ b/scenario_lab/core/orchestrator.py
@@ -79,7 +79,7 @@ class ScenarioOrchestrator:
 
         Args:
             event_bus: Event bus for emitting events (creates one if not provided)
-            end_turn: Turn number to stop at (e.g., end_turn=5 stops after turn 5)
+            end_turn: Number of turns to execute (e.g., end_turn=5 executes 5 actor decision rounds)
             credit_limit: Maximum cost in USD
             output_dir: Output directory for state saving
             save_state_every_turn: Whether to save state after each turn
@@ -403,6 +403,10 @@ class ScenarioOrchestrator:
             True if execution should stop
         """
         # Stop if end turn reached
+        # Note: state.turn represents the number of completed turns
+        # (0 = initial state, 1 = after 1st turn, 2 = after 2nd turn, etc.)
+        # So if we want N actor turns, we stop when state.turn >= N
+        # This means --end-turn N results in exactly N actor decision rounds
         if self.end_turn is not None and state.turn >= self.end_turn:
             return True
 

--- a/scenario_lab/interfaces/cli.py
+++ b/scenario_lab/interfaces/cli.py
@@ -59,7 +59,7 @@ def cli(verbose: bool) -> None:
 
 @cli.command()
 @click.argument("scenario_path", type=click.Path(exists=True, file_okay=False))
-@click.option("--end-turn", type=int, help="Turn number to stop at (e.g., --end-turn 5 stops after turn 5)")
+@click.option("--end-turn", type=int, help="Number of turns to execute (e.g., --end-turn 5 runs 5 actor decision rounds)")
 @click.option("--credit-limit", type=float, help="Maximum cost in USD")
 @click.option("--resume", type=click.Path(exists=True, file_okay=False), help="Resume from run directory")
 @click.option("--branch-from", type=click.Path(exists=True, file_okay=False), help="Branch from run directory")

--- a/scenario_lab/runners/sync_runner.py
+++ b/scenario_lab/runners/sync_runner.py
@@ -62,7 +62,7 @@ class SyncRunner:
         Args:
             scenario_path: Path to scenario directory
             output_path: Path to output directory
-            end_turn: Turn number to stop at (e.g., end_turn=5 stops after turn 5)
+            end_turn: Number of turns to execute (e.g., end_turn=5 executes 5 actor decision rounds)
             credit_limit: Maximum cost in USD
             database: Optional Database instance for persistence
             resume_from: Path to run directory to resume from

--- a/scenario_lab/services/world_update_phase_v2.py
+++ b/scenario_lab/services/world_update_phase_v2.py
@@ -151,8 +151,9 @@ class WorldUpdatePhaseV2:
         # Update state with new world state
         state = replace(state, world_state=new_world_state)
 
-        # Increment turn number (world update completes the turn)
-        state = replace(state, turn=state.turn + 1)
+        # Note: Turn number is managed by orchestrator, not by individual phases
+        # The orchestrator increments turn at the start of execute_turn()
+        # so we should NOT increment it here
 
         # Track costs
         cost_amount = calculate_cost(


### PR DESCRIPTION
Problem: When specifying --end-turn 2, the simulation would stop after
only 1 actor decision round instead of 2.

Root cause: The turn counter was being incremented in TWO places:
1. In orchestrator.execute_turn() at the start of each turn
2. In world_update_phase_v2.py at the end of each turn

This caused the turn counter to increment by 2 for each actual turn,
making --end-turn 2 stop after just 1 actor decision round (when turn
reached 2 prematurely).

Solution:
- Removed the duplicate turn increment from world_update_phase_v2.py
- Turn counter is now managed solely by the orchestrator
- Added clarifying comments explaining turn management
- Updated documentation to clarify that --end-turn N executes N turns

Changes:
- scenario_lab/services/world_update_phase_v2.py: Remove duplicate turn increment
- scenario_lab/core/orchestrator.py: Add clarifying comments
- scenario_lab/runners/sync_runner.py: Update docstring
- scenario_lab/interfaces/cli.py: Update help text
- CLAUDE.md: Update documentation

Result: --end-turn N now correctly executes exactly N actor decision rounds.