### PR TITLE
Fix #42: Document dev dependencies for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,13 @@ pip install -r requirements.txt
 3. **Run tests (optional but recommended):**
 
 ```bash
+# Install development dependencies first
+pip install -r requirements-dev.txt
+
+# Or install as editable package with dev dependencies
+pip install -e ".[dev]"
+
+# Then run tests
 pytest tests/
 ```
 


### PR DESCRIPTION
README previously instructed users to run tests without installing pytest-asyncio and other dev dependencies, causing test failures. Added instructions to install requirements-dev.txt or use pip install -e ".[dev]" before running tests.