### PR TITLE
Solve GitHub issue 41

### DIFF
--- a/docs/METRICS_MIGRATION.md
+++ b/docs/METRICS_MIGRATION.md
@@ -1,0 +1,337 @@
+# Metrics Configuration Migration Guide: V1 to V2
+
+This guide helps you migrate metrics.yaml files from the V1 format (dictionary-based) to the V2 format (list-based with Pydantic validation).
+
+## Why Migrate?
+
+The V2 metrics format provides:
+
+- **Strict validation** using Pydantic schemas
+- **Better type safety** with explicit `continuous`, `categorical`, and `boolean` types
+- **Clearer structure** with nested `extraction` configuration
+- **Per-metric thresholds** instead of a separate thresholds section
+- **Actor-specific metrics** support
+
+## Quick Reference: Format Differences
+
+| Aspect | V1 Format | V2 Format |
+|--------|-----------|-----------|
+| **Root extraction model** | `extraction_model:` (top-level) | `extraction.model:` (per-metric) |
+| **Extraction type** | `extraction_type:` | `extraction.type:` |
+| **LLM prompt** | `extraction_prompt:` | `extraction.prompt:` |
+| **Pattern/keywords** | Top-level on metric | Inside `extraction:` block |
+| **Data typing** | `data_type: "float"\|"integer"` | `type: "continuous"\|"categorical"\|"boolean"` |
+| **Value range** | Not required | `range: [min, max]` (required for continuous) |
+| **Categories** | Not required | `categories: [...]` (required for categorical) |
+| **Thresholds** | Separate `thresholds:` section | `warning_threshold:` / `critical_threshold:` on metric |
+| **Aggregation** | `aggregation: "max"\|"sum"\|"last"` | Removed (calculated per-turn) |
+
+## Migration Examples
+
+### Example 1: Pattern-Based Metric
+
+**V1 Format:**
+```yaml
+extraction_model: "openai/gpt-4o-mini"
+
+metrics:
+  budget_spent:
+    description: "Total budget spent in millions"
+    extraction_type: "pattern"
+    pattern: '\$(\d+(?:\.\d+)?)\s*(?:M|million)'
+    data_type: "float"
+    aggregation: "max"
+
+thresholds:
+  budget_spent:
+    warning: 8.0
+    critical: 10.0
+```
+
+**V2 Format:**
+```yaml
+metrics:
+  - name: budget_spent
+    description: "Total budget spent in millions"
+    type: continuous
+    range: [0, 10]
+    unit: "M$"
+    extraction:
+      type: pattern
+      pattern: '\$(\d+(?:\.\d+)?)\s*(?:M|million)'
+    warning_threshold: 8.0
+    critical_threshold: 10.0
+    actor_specific: false
+
+export_format: json
+```
+
+### Example 2: Keyword-Based Metric
+
+**V1 Format:**
+```yaml
+metrics:
+  privacy_concerns:
+    description: "Privacy concern mentions"
+    extraction_type: "keyword"
+    keywords:
+      - "privacy"
+      - "surveillance"
+      - "data protection"
+    data_type: "integer"
+    aggregation: "sum"
+```
+
+**V2 Format:**
+```yaml
+metrics:
+  - name: privacy_concerns
+    description: "Privacy concern mentions"
+    type: continuous
+    range: [0, 100]
+    unit: "mentions"
+    extraction:
+      type: keyword
+      keywords:
+        - "privacy"
+        - "surveillance"
+        - "data protection"
+      scoring: count
+    actor_specific: false
+```
+
+### Example 3: LLM-Based Metric
+
+**V1 Format:**
+```yaml
+extraction_model: "openai/gpt-4o-mini"
+
+metrics:
+  support_level:
+    description: "Public support level (0-10)"
+    extraction_type: "llm"
+    extraction_prompt: |
+      Rate the public support level on a scale of 0-10.
+      Respond with only a number.
+    data_type: "integer"
+    aggregation: "last"
+```
+
+**V2 Format:**
+```yaml
+metrics:
+  - name: support_level
+    description: "Public support level (0-10)"
+    type: continuous
+    range: [0, 10]
+    unit: "support"
+    extraction:
+      type: llm
+      prompt: |
+        Rate the public support level on a scale of 0-10.
+        Respond with only a number.
+      model: "openai/gpt-4o-mini"  # Optional: per-metric model
+    actor_specific: false
+
+export_format: json
+```
+
+### Example 4: Categorical Metric
+
+**V1 Format:**
+```yaml
+metrics:
+  scenario_outcome:
+    description: "Scenario trajectory"
+    extraction_type: "keyword"
+    keywords:
+      - "cooperation"
+      - "conflict"
+      - "stalemate"
+    data_type: "string"
+    aggregation: "last"
+```
+
+**V2 Format:**
+```yaml
+metrics:
+  - name: scenario_outcome
+    description: "Scenario trajectory"
+    type: categorical
+    categories:
+      - "cooperation"
+      - "conflict"
+      - "stalemate"
+    extraction:
+      type: keyword
+      keywords:
+        - "cooperation"
+        - "conflict"
+        - "stalemate"
+      scoring: presence
+    actor_specific: false
+```
+
+## Step-by-Step Migration Checklist
+
+Use this checklist to convert your V1 metrics.yaml to V2:
+
+### 1. Structure Changes
+
+- [ ] **Convert metrics from dict to list**: Change `metrics: {name: {...}}` to `metrics: [{name: "...", ...}]`
+- [ ] **Add `name` field**: Move the metric key to a `name` field inside each metric object
+
+### 2. Field Renames
+
+- [ ] **`extraction_type`** → `extraction.type`
+- [ ] **`extraction_prompt`** → `extraction.prompt`
+- [ ] **`pattern`** → `extraction.pattern`
+- [ ] **`keywords`** → `extraction.keywords`
+
+### 3. Type System Changes
+
+- [ ] **Replace `data_type`** with `type` using V2 values:
+  - `"float"` → `continuous`
+  - `"integer"` → `continuous`
+  - `"string"` → `categorical`
+  - `"bool"` → `boolean`
+
+### 4. Required Fields for Each Type
+
+- [ ] **Continuous metrics**: Add `range: [min, max]`
+- [ ] **Categorical metrics**: Add `categories: ["option1", "option2", ...]`
+- [ ] **Boolean metrics**: No additional fields required
+
+### 5. Thresholds Migration
+
+- [ ] **Remove `thresholds:` section**
+- [ ] **Move thresholds to metrics**: Add `warning_threshold:` and `critical_threshold:` to each metric
+
+### 6. Cleanup
+
+- [ ] **Remove `extraction_model:`** from top level (move to `extraction.model:` per-metric if needed)
+- [ ] **Remove `aggregation:`** field (no longer used)
+- [ ] **Add `unit:`** label (optional but recommended)
+- [ ] **Add `actor_specific: false`** (optional, defaults to false)
+- [ ] **Add `export_format: json`** at root level (optional, defaults to json)
+
+## Automated Migration Tool
+
+A migration tool is available to automatically convert V1 metrics files to V2 format:
+
+```bash
+# Convert a single metrics file
+python -m scenario_lab.tools.migrate_metrics scenarios/my-scenario/metrics.yaml
+
+# Preview changes without writing
+python -m scenario_lab.tools.migrate_metrics scenarios/my-scenario/metrics.yaml --dry-run
+
+# Output to different file
+python -m scenario_lab.tools.migrate_metrics scenarios/my-scenario/metrics.yaml --output metrics-v2.yaml
+```
+
+The tool will:
+
+1. Detect if the file is V1 format
+2. Convert all fields to V2 schema
+3. Preserve comments where possible
+4. Validate the output against V2 schema
+5. Create a backup of the original file
+
+## Common Validation Errors After Migration
+
+If validation fails after migration, check for these common issues:
+
+### Missing `type` field
+
+```
+ValueError: field required (type=value_error.missing)
+```
+
+**Fix:** Add `type: continuous`, `type: categorical`, or `type: boolean`
+
+### Missing `range` for continuous metrics
+
+```
+ValueError: 'range' field required for continuous metrics
+```
+
+**Fix:** Add `range: [min_value, max_value]` (e.g., `range: [0, 10]`)
+
+### Missing `categories` for categorical metrics
+
+```
+ValueError: 'categories' field required for categorical metrics
+```
+
+**Fix:** Add `categories: ["option1", "option2", ...]`
+
+### Invalid metric name
+
+```
+ValueError: string does not match regex "^[a-z0-9_]+$"
+```
+
+**Fix:** Use lowercase with underscores only (e.g., `public_support` not `Public-Support`)
+
+### Missing extraction prompt
+
+```
+ValueError: 'prompt' field required when type is 'llm'
+```
+
+**Fix:** Add `prompt:` inside the `extraction:` block
+
+### Duplicate metric names
+
+```
+ValueError: Duplicate metric names found: {'metric_name'}
+```
+
+**Fix:** Ensure each metric has a unique `name`
+
+## V2 Schema Reference
+
+### MetricsConfig (Root)
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `metrics` | list | Yes | - | List of metric configurations |
+| `export_format` | string | No | "json" | "json", "csv", or "both" |
+| `auto_export` | boolean | No | true | Auto-export after each turn |
+| `export_path` | string | No | null | Custom export location |
+
+### MetricConfig (Individual Metric)
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | Yes | - | Identifier (lowercase_with_underscores) |
+| `description` | string | Yes | - | What the metric measures |
+| `type` | string | Yes | - | "continuous", "categorical", or "boolean" |
+| `extraction` | object | Yes | - | How to extract the metric |
+| `range` | [float, float] | Yes* | - | *Required for continuous type |
+| `categories` | list | Yes* | - | *Required for categorical type |
+| `unit` | string | No | null | Unit label (e.g., "percent") |
+| `actor_specific` | boolean | No | false | Per-actor tracking |
+| `warning_threshold` | float | No | null | Warning trigger value |
+| `critical_threshold` | float | No | null | Critical alert trigger |
+
+### MetricExtraction
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | string | Yes | - | "llm", "keyword", "pattern", or "manual" |
+| `prompt` | string | Yes* | - | *Required when type="llm" |
+| `model` | string | No | null | LLM model for extraction |
+| `keywords` | list | Yes* | - | *Required when type="keyword" |
+| `scoring` | string | No | "count" | "count", "presence", or "density" |
+| `pattern` | string | Yes* | - | *Required when type="pattern" |
+
+## Getting Help
+
+If you encounter issues during migration:
+
+1. **Check the examples** in `scenarios/example-full-featured/metrics.yaml`
+2. **Run validation** with `scenario-lab validate scenarios/your-scenario`
+3. **Review the schema** in `scenario_lab/schemas/metrics.py`
+4. **Report issues** at https://github.com/Itangalo/scenario-lab/issues

--- a/scenario_lab/loaders/metrics_loader.py
+++ b/scenario_lab/loaders/metrics_loader.py
@@ -2,6 +2,7 @@
 Metrics Config Loader for Scenario Lab V2
 
 Loads and validates metrics.yaml files using Pydantic schemas.
+Includes detection of V1 format with helpful migration guidance.
 """
 import yaml
 import logging
@@ -11,6 +12,82 @@ from typing import Optional
 from scenario_lab.schemas.metrics import MetricsConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _detect_v1_format(data: dict) -> tuple[bool, list[str]]:
+    """
+    Detect if metrics data is in V1 format and identify V1 indicators.
+
+    Returns:
+        Tuple of (is_v1_format, list_of_v1_indicators)
+    """
+    if not isinstance(data, dict):
+        return False, []
+
+    v1_indicators = []
+
+    # V1 has top-level extraction_model
+    if "extraction_model" in data:
+        v1_indicators.append("top-level 'extraction_model' field (move to extraction.model per metric)")
+
+    # V1 has separate thresholds section
+    if "thresholds" in data:
+        v1_indicators.append("separate 'thresholds' section (move to warning_threshold/critical_threshold per metric)")
+
+    # Check metrics structure
+    metrics = data.get("metrics")
+
+    # V1: metrics is a dict with metric names as keys
+    if isinstance(metrics, dict):
+        v1_indicators.append("'metrics' is a dictionary (should be a list of metric objects)")
+
+    # V1: metrics is a list but with V1 fields
+    if isinstance(metrics, list) and len(metrics) > 0:
+        first_metric = metrics[0]
+        if isinstance(first_metric, dict):
+            if "extraction_type" in first_metric:
+                v1_indicators.append("'extraction_type' field (use nested 'extraction.type' instead)")
+            if "extraction_prompt" in first_metric:
+                v1_indicators.append("'extraction_prompt' field (use nested 'extraction.prompt' instead)")
+            if "data_type" in first_metric:
+                v1_indicators.append("'data_type' field (use 'type: continuous|categorical|boolean' instead)")
+            if "aggregation" in first_metric:
+                v1_indicators.append("'aggregation' field (removed in V2, metrics are per-turn)")
+
+    return len(v1_indicators) > 0, v1_indicators
+
+
+def _format_v1_migration_error(v1_indicators: list[str], file_path: Path) -> str:
+    """Format a helpful error message for V1 format detection"""
+    lines = [
+        f"V1 metrics format detected in {file_path}",
+        "",
+        "The metrics.yaml file uses V1 format which is no longer supported.",
+        "V1 indicators found:",
+    ]
+
+    for indicator in v1_indicators:
+        lines.append(f"  - {indicator}")
+
+    lines.extend([
+        "",
+        "To migrate to V2 format:",
+        "",
+        "  Option 1: Use the automated migration tool:",
+        f"    python -m scenario_lab.tools.migrate_metrics {file_path}",
+        "",
+        "  Option 2: Follow the manual migration guide:",
+        "    See docs/METRICS_MIGRATION.md for step-by-step instructions",
+        "",
+        "Quick reference - V1 to V2 changes:",
+        "  - extraction_type → extraction.type",
+        "  - extraction_prompt → extraction.prompt",
+        "  - data_type: float/integer → type: continuous + range: [min, max]",
+        "  - data_type: string → type: categorical + categories: [...]",
+        "  - thresholds.metric.warning → metric.warning_threshold",
+    ])
+
+    return "\n".join(lines)
 
 
 def load_metrics_config(metrics_file: Path) -> Optional[MetricsConfig]:
@@ -24,7 +101,7 @@ def load_metrics_config(metrics_file: Path) -> Optional[MetricsConfig]:
         Validated MetricsConfig object, or None if file doesn't exist or is invalid
 
     Raises:
-        ValueError: If YAML is invalid or doesn't match schema
+        ValueError: If YAML is invalid, uses V1 format, or doesn't match V2 schema
     """
     if not metrics_file.exists():
         logger.debug(f"No metrics file found at {metrics_file}")
@@ -38,6 +115,13 @@ def load_metrics_config(metrics_file: Path) -> Optional[MetricsConfig]:
             logger.warning(f"Empty metrics file: {metrics_file}")
             return None
 
+        # Check for V1 format and provide helpful migration guidance
+        is_v1, v1_indicators = _detect_v1_format(data)
+        if is_v1:
+            error_message = _format_v1_migration_error(v1_indicators, metrics_file)
+            logger.error(f"V1 metrics format detected in {metrics_file}")
+            raise ValueError(error_message)
+
         # Validate with Pydantic
         config = MetricsConfig(**data)
 
@@ -47,6 +131,10 @@ def load_metrics_config(metrics_file: Path) -> Optional[MetricsConfig]:
     except yaml.YAMLError as e:
         logger.error(f"Invalid YAML in {metrics_file}: {e}")
         raise ValueError(f"Invalid YAML in metrics file: {e}")
+
+    except ValueError:
+        # Re-raise ValueError (including V1 format errors) without wrapping
+        raise
 
     except Exception as e:
         logger.error(f"Failed to load metrics config from {metrics_file}: {e}")

--- a/scenario_lab/tools/__init__.py
+++ b/scenario_lab/tools/__init__.py
@@ -1,0 +1,5 @@
+"""
+Scenario Lab Tools
+
+Utility scripts for migration, validation, and maintenance tasks.
+"""

--- a/scenario_lab/tools/migrate_metrics.py
+++ b/scenario_lab/tools/migrate_metrics.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""
+Metrics Configuration Migration Tool: V1 to V2
+
+Automatically converts V1 metrics.yaml files (dictionary-based) to V2 format
+(list-based with Pydantic validation).
+
+Usage:
+    python -m scenario_lab.tools.migrate_metrics <metrics_file>
+    python -m scenario_lab.tools.migrate_metrics <metrics_file> --dry-run
+    python -m scenario_lab.tools.migrate_metrics <metrics_file> --output metrics-v2.yaml
+"""
+
+import argparse
+import sys
+import shutil
+from pathlib import Path
+from typing import Any
+from datetime import datetime
+
+import yaml
+
+from scenario_lab.schemas.metrics import MetricsConfig
+
+
+def detect_v1_format(data: dict) -> bool:
+    """
+    Detect if metrics data is in V1 format.
+
+    V1 indicators:
+    - Top-level 'extraction_model' field
+    - 'metrics' is a dict (not a list)
+    - Metrics have 'extraction_type' instead of nested 'extraction'
+    - Separate 'thresholds' section
+    - 'data_type' field instead of 'type'
+    """
+    if not isinstance(data, dict):
+        return False
+
+    # V1 has top-level extraction_model
+    if "extraction_model" in data:
+        return True
+
+    # V1 has separate thresholds section
+    if "thresholds" in data:
+        return True
+
+    # Check metrics structure
+    metrics = data.get("metrics")
+    if metrics is None:
+        return False
+
+    # V1: metrics is a dict with metric names as keys
+    if isinstance(metrics, dict):
+        return True
+
+    # V1: metrics is a list but with V1 fields
+    if isinstance(metrics, list) and len(metrics) > 0:
+        first_metric = metrics[0]
+        if isinstance(first_metric, dict):
+            # V1 indicators in metric definition
+            if "extraction_type" in first_metric:
+                return True
+            if "extraction_prompt" in first_metric:
+                return True
+            if "data_type" in first_metric:
+                return True
+            if "aggregation" in first_metric:
+                return True
+
+    return False
+
+
+def convert_data_type_to_v2_type(data_type: str) -> str:
+    """Convert V1 data_type to V2 type"""
+    mapping = {
+        "float": "continuous",
+        "integer": "continuous",
+        "int": "continuous",
+        "number": "continuous",
+        "string": "categorical",
+        "str": "categorical",
+        "bool": "boolean",
+        "boolean": "boolean",
+    }
+    return mapping.get(data_type.lower(), "continuous")
+
+
+def infer_range_from_prompt(prompt: str) -> tuple[float, float]:
+    """Attempt to infer range from LLM prompt"""
+    import re
+
+    # Look for patterns like "0-10", "1-5", "0 to 100"
+    patterns = [
+        r"(\d+)\s*[-–to]\s*(\d+)\s*scale",
+        r"scale\s*(?:of|from)?\s*(\d+)\s*[-–to]\s*(\d+)",
+        r"(\d+)\s*[-–to]\s*(\d+)",
+        r"between\s*(\d+)\s*and\s*(\d+)",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, prompt, re.IGNORECASE)
+        if match:
+            min_val = float(match.group(1))
+            max_val = float(match.group(2))
+            if min_val < max_val:
+                return (min_val, max_val)
+
+    # Default range
+    return (0, 10)
+
+
+def migrate_metric(
+    name: str,
+    v1_metric: dict,
+    extraction_model: str | None = None,
+    thresholds: dict | None = None,
+) -> dict:
+    """Convert a single V1 metric to V2 format"""
+    v2_metric: dict[str, Any] = {
+        "name": name,
+        "description": v1_metric.get("description", f"Metric: {name}"),
+    }
+
+    # Convert data_type to type
+    data_type = v1_metric.get("data_type", "float")
+    v2_type = convert_data_type_to_v2_type(data_type)
+    v2_metric["type"] = v2_type
+
+    # Build extraction block
+    extraction: dict[str, Any] = {}
+
+    extraction_type = v1_metric.get("extraction_type", "manual")
+    extraction["type"] = extraction_type
+
+    if extraction_type == "llm":
+        prompt = v1_metric.get("extraction_prompt", v1_metric.get("prompt", ""))
+        extraction["prompt"] = prompt
+
+        # Add model if specified
+        model = v1_metric.get("model") or extraction_model
+        if model:
+            extraction["model"] = model
+
+        # Infer range from prompt for continuous metrics
+        if v2_type == "continuous":
+            v2_metric["range"] = infer_range_from_prompt(prompt)
+
+    elif extraction_type == "keyword":
+        keywords = v1_metric.get("keywords", [])
+        extraction["keywords"] = keywords
+
+        # Add scoring if specified
+        scoring = v1_metric.get("scoring", "count")
+        extraction["scoring"] = scoring
+
+        # Default range for keyword metrics
+        if v2_type == "continuous":
+            v2_metric["range"] = (0, 100)
+
+    elif extraction_type == "pattern":
+        pattern = v1_metric.get("pattern", "")
+        extraction["pattern"] = pattern
+
+        # Default range for pattern metrics
+        if v2_type == "continuous":
+            v2_metric["range"] = (0, 100)
+
+    else:  # manual or unknown
+        extraction["type"] = "manual"
+        if v2_type == "continuous":
+            v2_metric["range"] = (0, 100)
+
+    v2_metric["extraction"] = extraction
+
+    # Handle categorical type
+    if v2_type == "categorical":
+        # Try to get categories from keywords or create defaults
+        keywords = v1_metric.get("keywords", [])
+        if keywords:
+            v2_metric["categories"] = keywords
+        else:
+            v2_metric["categories"] = ["unknown"]
+        # Remove range if it was set
+        v2_metric.pop("range", None)
+
+    # Handle boolean type
+    if v2_type == "boolean":
+        v2_metric.pop("range", None)
+        v2_metric.pop("categories", None)
+
+    # Add unit if available
+    unit = v1_metric.get("unit")
+    if unit:
+        v2_metric["unit"] = unit
+    elif v2_type == "continuous":
+        # Infer unit from metric name or description
+        if "percent" in name.lower() or "percent" in v2_metric["description"].lower():
+            v2_metric["unit"] = "percent"
+        elif "count" in name.lower() or "mention" in name.lower():
+            v2_metric["unit"] = "count"
+
+    # Add thresholds if available
+    if thresholds and name in thresholds:
+        metric_thresholds = thresholds[name]
+        if "warning" in metric_thresholds:
+            v2_metric["warning_threshold"] = metric_thresholds["warning"]
+        if "critical" in metric_thresholds:
+            v2_metric["critical_threshold"] = metric_thresholds["critical"]
+
+    # Add actor_specific
+    v2_metric["actor_specific"] = v1_metric.get("actor_specific", False)
+
+    return v2_metric
+
+
+def migrate_v1_to_v2(v1_data: dict) -> dict:
+    """Convert V1 metrics configuration to V2 format"""
+    v2_data: dict[str, Any] = {"metrics": []}
+
+    # Extract top-level V1 fields
+    extraction_model = v1_data.get("extraction_model")
+    thresholds = v1_data.get("thresholds", {})
+
+    # Get metrics
+    v1_metrics = v1_data.get("metrics", {})
+
+    # Handle dict-based metrics (V1 style)
+    if isinstance(v1_metrics, dict):
+        for name, metric_def in v1_metrics.items():
+            v2_metric = migrate_metric(name, metric_def, extraction_model, thresholds)
+            v2_data["metrics"].append(v2_metric)
+
+    # Handle list-based metrics that still have V1 fields
+    elif isinstance(v1_metrics, list):
+        for metric_def in v1_metrics:
+            name = metric_def.get("name", f"metric_{len(v2_data['metrics'])}")
+            v2_metric = migrate_metric(name, metric_def, extraction_model, thresholds)
+            v2_data["metrics"].append(v2_metric)
+
+    # Add export settings
+    v2_data["export_format"] = v1_data.get("export_format", "json")
+    v2_data["auto_export"] = v1_data.get("auto_export", True)
+
+    return v2_data
+
+
+def validate_v2_config(v2_data: dict) -> tuple[bool, str | None]:
+    """Validate V2 configuration against Pydantic schema"""
+    try:
+        MetricsConfig(**v2_data)
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def format_yaml_output(data: dict) -> str:
+    """Format data as YAML with nice formatting"""
+
+    class CustomDumper(yaml.SafeDumper):
+        # Disable aliases to avoid confusing &id001/*id001 references
+        def ignore_aliases(self, data):
+            return True
+
+    def str_representer(dumper, data):
+        if "\n" in data:
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+    def list_representer(dumper, data):
+        # Use flow style for simple lists (numbers, short strings)
+        if all(isinstance(item, (int, float)) for item in data):
+            return dumper.represent_sequence(
+                "tag:yaml.org,2002:seq", data, flow_style=True
+            )
+        if all(
+            isinstance(item, str) and len(item) < 30 and "\n" not in item
+            for item in data
+        ):
+            if len(data) <= 5:
+                return dumper.represent_sequence(
+                    "tag:yaml.org,2002:seq", data, flow_style=True
+                )
+        return dumper.represent_sequence("tag:yaml.org,2002:seq", data)
+
+    CustomDumper.add_representer(str, str_representer)
+    CustomDumper.add_representer(list, list_representer)
+
+    return yaml.dump(
+        data,
+        Dumper=CustomDumper,
+        default_flow_style=False,
+        allow_unicode=True,
+        sort_keys=False,
+        width=100,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Migrate metrics.yaml from V1 to V2 format",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s scenarios/my-scenario/metrics.yaml
+  %(prog)s metrics.yaml --dry-run
+  %(prog)s metrics.yaml --output metrics-v2.yaml
+
+For more information, see docs/METRICS_MIGRATION.md
+        """,
+    )
+    parser.add_argument("input_file", type=Path, help="Path to V1 metrics.yaml file")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Output file path (default: overwrite input file)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        action="store_true",
+        help="Preview changes without writing",
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Don't create backup of original file",
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Convert even if file appears to be V2 format",
+    )
+
+    args = parser.parse_args()
+
+    # Check input file exists
+    if not args.input_file.exists():
+        print(f"Error: File not found: {args.input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Read input file
+    try:
+        with open(args.input_file) as f:
+            v1_data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        print(f"Error: Invalid YAML in {args.input_file}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not v1_data:
+        print(f"Error: Empty file: {args.input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Check if already V2 format
+    if not detect_v1_format(v1_data) and not args.force:
+        print(f"File appears to already be in V2 format: {args.input_file}")
+        print("Use --force to convert anyway.")
+        sys.exit(0)
+
+    # Perform migration
+    print(f"Migrating: {args.input_file}")
+    v2_data = migrate_v1_to_v2(v1_data)
+
+    # Validate result
+    valid, error = validate_v2_config(v2_data)
+    if not valid:
+        print(f"Warning: Migrated config has validation issues: {error}", file=sys.stderr)
+        print("You may need to manually fix the output.", file=sys.stderr)
+
+    # Format output
+    output_yaml = format_yaml_output(v2_data)
+
+    # Dry run: just print
+    if args.dry_run:
+        print("\n--- Migrated V2 Configuration ---\n")
+        print(output_yaml)
+        if valid:
+            print("\n✓ Configuration validates successfully")
+        else:
+            print(f"\n⚠ Validation issues: {error}")
+        return
+
+    # Determine output path
+    output_path = args.output or args.input_file
+
+    # Create backup if overwriting
+    if output_path == args.input_file and not args.no_backup:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        backup_path = args.input_file.with_suffix(f".v1.{timestamp}.yaml")
+        shutil.copy2(args.input_file, backup_path)
+        print(f"Backup created: {backup_path}")
+
+    # Write output
+    with open(output_path, "w") as f:
+        f.write(output_yaml)
+
+    print(f"Migrated configuration written to: {output_path}")
+
+    if valid:
+        print("✓ Configuration validates successfully")
+    else:
+        print(f"⚠ Validation issues (manual fixes may be needed): {error}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sample_v1_metrics.yaml
+++ b/tests/fixtures/sample_v1_metrics.yaml
@@ -1,0 +1,48 @@
+# Sample V1 metrics format for migration testing
+extraction_model: "openai/gpt-4o-mini"
+
+metrics:
+  budget_spent:
+    description: "Total budget spent in millions"
+    extraction_type: "pattern"
+    pattern: '\$(\d+(?:\.\d+)?)\s*(?:M|million)'
+    data_type: "float"
+    aggregation: "max"
+
+  privacy_concerns:
+    description: "Privacy concern mentions"
+    extraction_type: "keyword"
+    keywords:
+      - "privacy"
+      - "surveillance"
+      - "data protection"
+    data_type: "integer"
+    aggregation: "sum"
+
+  support_level:
+    description: "Public support level (0-10)"
+    extraction_type: "llm"
+    extraction_prompt: |
+      Rate the public support level on a scale of 0-10.
+      Consider media coverage, public statements, and stakeholder reactions.
+      Respond with only a number.
+    data_type: "integer"
+    aggregation: "last"
+
+  scenario_outcome:
+    description: "Scenario trajectory"
+    extraction_type: "keyword"
+    keywords:
+      - "cooperation"
+      - "conflict"
+      - "stalemate"
+    data_type: "string"
+    aggregation: "last"
+
+thresholds:
+  budget_spent:
+    warning: 8.0
+    critical: 10.0
+  support_level:
+    warning: 3.0
+    critical: 2.0

--- a/tests/test_migrate_metrics.py
+++ b/tests/test_migrate_metrics.py
@@ -1,0 +1,275 @@
+"""
+Tests for the V1 to V2 metrics migration tool.
+"""
+import pytest
+from scenario_lab.tools.migrate_metrics import (
+    detect_v1_format,
+    migrate_v1_to_v2,
+    convert_data_type_to_v2_type,
+    infer_range_from_prompt,
+)
+from scenario_lab.loaders.metrics_loader import load_metrics_config, _detect_v1_format
+from scenario_lab.schemas.metrics import MetricsConfig
+from pathlib import Path
+
+
+class TestV1FormatDetection:
+    """Tests for V1 format detection"""
+
+    def test_detects_extraction_model(self):
+        """Top-level extraction_model indicates V1"""
+        data = {
+            "extraction_model": "openai/gpt-4o-mini",
+            "metrics": []
+        }
+        assert detect_v1_format(data) is True
+
+    def test_detects_thresholds_section(self):
+        """Separate thresholds section indicates V1"""
+        data = {
+            "metrics": [],
+            "thresholds": {"metric1": {"warning": 5}}
+        }
+        assert detect_v1_format(data) is True
+
+    def test_detects_dict_metrics(self):
+        """Dict-based metrics indicate V1"""
+        data = {
+            "metrics": {
+                "metric1": {"description": "test"}
+            }
+        }
+        assert detect_v1_format(data) is True
+
+    def test_detects_extraction_type_field(self):
+        """extraction_type field in metric indicates V1"""
+        data = {
+            "metrics": [
+                {"name": "test", "extraction_type": "llm"}
+            ]
+        }
+        assert detect_v1_format(data) is True
+
+    def test_detects_data_type_field(self):
+        """data_type field in metric indicates V1"""
+        data = {
+            "metrics": [
+                {"name": "test", "data_type": "float"}
+            ]
+        }
+        assert detect_v1_format(data) is True
+
+    def test_detects_aggregation_field(self):
+        """aggregation field in metric indicates V1"""
+        data = {
+            "metrics": [
+                {"name": "test", "aggregation": "sum"}
+            ]
+        }
+        assert detect_v1_format(data) is True
+
+    def test_v2_format_not_detected(self):
+        """V2 format should not be detected as V1"""
+        data = {
+            "metrics": [
+                {
+                    "name": "test",
+                    "description": "Test metric",
+                    "type": "continuous",
+                    "range": [0, 10],
+                    "extraction": {"type": "llm", "prompt": "test"}
+                }
+            ]
+        }
+        assert detect_v1_format(data) is False
+
+
+class TestDataTypeConversion:
+    """Tests for V1 data_type to V2 type conversion"""
+
+    def test_float_to_continuous(self):
+        assert convert_data_type_to_v2_type("float") == "continuous"
+
+    def test_integer_to_continuous(self):
+        assert convert_data_type_to_v2_type("integer") == "continuous"
+
+    def test_int_to_continuous(self):
+        assert convert_data_type_to_v2_type("int") == "continuous"
+
+    def test_string_to_categorical(self):
+        assert convert_data_type_to_v2_type("string") == "categorical"
+
+    def test_bool_to_boolean(self):
+        assert convert_data_type_to_v2_type("bool") == "boolean"
+
+    def test_unknown_defaults_continuous(self):
+        assert convert_data_type_to_v2_type("unknown") == "continuous"
+
+
+class TestRangeInference:
+    """Tests for inferring range from LLM prompts"""
+
+    def test_infers_0_to_10_scale(self):
+        prompt = "Rate the cooperation level on a 0-10 scale"
+        assert infer_range_from_prompt(prompt) == (0, 10)
+
+    def test_infers_1_to_5_scale(self):
+        prompt = "Rate on a 1-5 scale"
+        assert infer_range_from_prompt(prompt) == (1, 5)
+
+    def test_infers_scale_of_pattern(self):
+        prompt = "Give a score on a scale of 0-100"
+        assert infer_range_from_prompt(prompt) == (0, 100)
+
+    def test_defaults_when_no_range(self):
+        prompt = "Assess the general situation"
+        assert infer_range_from_prompt(prompt) == (0, 10)
+
+
+class TestV1ToV2Migration:
+    """Tests for full V1 to V2 migration"""
+
+    def test_migrates_dict_metrics(self):
+        """V1 dict-based metrics are converted to V2 list"""
+        v1_data = {
+            "extraction_model": "openai/gpt-4o-mini",
+            "metrics": {
+                "test_metric": {
+                    "description": "A test metric",
+                    "extraction_type": "llm",
+                    "extraction_prompt": "Rate from 0-10",
+                    "data_type": "float"
+                }
+            }
+        }
+
+        v2_data = migrate_v1_to_v2(v1_data)
+
+        assert "metrics" in v2_data
+        assert isinstance(v2_data["metrics"], list)
+        assert len(v2_data["metrics"]) == 1
+
+        metric = v2_data["metrics"][0]
+        assert metric["name"] == "test_metric"
+        assert metric["type"] == "continuous"
+        assert "extraction" in metric
+        assert metric["extraction"]["type"] == "llm"
+        assert "prompt" in metric["extraction"]
+
+    def test_migrates_thresholds(self):
+        """V1 thresholds section is migrated to per-metric thresholds"""
+        v1_data = {
+            "metrics": {
+                "test_metric": {
+                    "description": "Test",
+                    "extraction_type": "pattern",
+                    "pattern": r"\d+",
+                    "data_type": "float"
+                }
+            },
+            "thresholds": {
+                "test_metric": {
+                    "warning": 7.0,
+                    "critical": 9.0
+                }
+            }
+        }
+
+        v2_data = migrate_v1_to_v2(v1_data)
+
+        metric = v2_data["metrics"][0]
+        assert metric["warning_threshold"] == 7.0
+        assert metric["critical_threshold"] == 9.0
+
+    def test_migrates_keyword_metric(self):
+        """V1 keyword metrics are properly migrated"""
+        v1_data = {
+            "metrics": {
+                "keyword_metric": {
+                    "description": "Keyword count",
+                    "extraction_type": "keyword",
+                    "keywords": ["test", "example"],
+                    "data_type": "integer"
+                }
+            }
+        }
+
+        v2_data = migrate_v1_to_v2(v1_data)
+
+        metric = v2_data["metrics"][0]
+        assert metric["extraction"]["type"] == "keyword"
+        assert metric["extraction"]["keywords"] == ["test", "example"]
+        assert metric["extraction"]["scoring"] == "count"
+
+    def test_migrates_categorical_metric(self):
+        """V1 string data_type becomes categorical with categories"""
+        v1_data = {
+            "metrics": {
+                "outcome": {
+                    "description": "Scenario outcome",
+                    "extraction_type": "keyword",
+                    "keywords": ["success", "failure"],
+                    "data_type": "string"
+                }
+            }
+        }
+
+        v2_data = migrate_v1_to_v2(v1_data)
+
+        metric = v2_data["metrics"][0]
+        assert metric["type"] == "categorical"
+        assert metric["categories"] == ["success", "failure"]
+        assert "range" not in metric
+
+    def test_result_validates(self):
+        """Migrated output validates against V2 schema"""
+        v1_data = {
+            "extraction_model": "openai/gpt-4o-mini",
+            "metrics": {
+                "test_metric": {
+                    "description": "A test metric",
+                    "extraction_type": "llm",
+                    "extraction_prompt": "Rate from 0-10",
+                    "data_type": "float"
+                }
+            }
+        }
+
+        v2_data = migrate_v1_to_v2(v1_data)
+
+        # Should not raise
+        config = MetricsConfig(**v2_data)
+        assert len(config.metrics) == 1
+
+
+class TestLoaderV1Detection:
+    """Tests for V1 detection in the metrics loader"""
+
+    def test_loader_detect_v1_format(self):
+        """Loader's _detect_v1_format returns indicators"""
+        data = {
+            "extraction_model": "test",
+            "thresholds": {}
+        }
+
+        is_v1, indicators = _detect_v1_format(data)
+
+        assert is_v1 is True
+        assert len(indicators) >= 2
+        assert any("extraction_model" in ind for ind in indicators)
+        assert any("thresholds" in ind for ind in indicators)
+
+    def test_loader_raises_on_v1_file(self):
+        """Loading V1 file raises ValueError with helpful message"""
+        v1_file = Path("tests/fixtures/sample_v1_metrics.yaml")
+
+        if not v1_file.exists():
+            pytest.skip("Sample V1 metrics file not found")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_metrics_config(v1_file)
+
+        error_msg = str(exc_info.value)
+        assert "V1 metrics format detected" in error_msg
+        assert "migrate_metrics" in error_msg
+        assert "METRICS_MIGRATION.md" in error_msg


### PR DESCRIPTION
This commit addresses the metrics YAML format incompatibility between V1 (dictionary-based) and V2 (list-based with Pydantic validation).

Changes:
- Add docs/METRICS_MIGRATION.md with comprehensive migration guide
- Add scenario_lab/tools/migrate_metrics.py automated migration tool
- Update metrics_loader.py to detect V1 format and provide helpful error messages with migration instructions
- Add tests for migration functionality (24 tests, all passing)
- Add sample V1 metrics file for testing

The migration tool supports:
- Automatic V1 format detection
- Conversion of dict-based to list-based metrics
- Field renames (extraction_type → extraction.type, etc.)
- Type conversion (data_type → type with proper values)
- Range inference from LLM prompts
- Threshold migration from separate section to per-metric
- Dry-run preview mode
- Backup creation before overwriting

Users can migrate with:
  python -m scenario_lab.tools.migrate_metrics <metrics_file>