### PR TITLE
Fix reported issue

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@ Execute a scenario in the background.
 ```json
 {
   "scenario_path": "scenarios/ai-summit",
-  "max_turns": 10,
+  "end_turn": 10,
   "credit_limit": 5.0,
   "output_path": "output/custom-path",
   "enable_database": true
@@ -213,7 +213,7 @@ client = ScenarioLabClient("http://localhost:8000")
 # Execute scenario
 result = await client.execute_scenario(
     scenario_path="scenarios/ai-summit",
-    max_turns=10,
+    end_turn=10,
     credit_limit=5.0
 )
 

--- a/docs/DATABASE_ANALYTICS_GUIDE.md
+++ b/docs/DATABASE_ANALYTICS_GUIDE.md
@@ -258,7 +258,7 @@ db = Database("scenarios.db")
 
 executor = AsyncExecutor(
     scenario_path="scenarios/ai-2027",
-    max_turns=10,
+    end_turn=10,
 )
 
 # Note: Database needs to be passed to SyncRunner internally

--- a/examples/api_client.py
+++ b/examples/api_client.py
@@ -154,7 +154,7 @@ async def example_execute_and_monitor():
         print("🚀 Starting scenario execution...")
         result = await client.execute_scenario(
             scenario_path="scenarios/test-regulation-negotiation",
-            max_turns=3,
+            end_turn=3,
             credit_limit=1.0,
         )
 
@@ -190,7 +190,7 @@ async def example_with_websocket():
         print("🚀 Starting scenario with WebSocket streaming...")
         result = await client.execute_scenario(
             scenario_path="scenarios/test-regulation-negotiation",
-            max_turns=3,
+            end_turn=3,
         )
 
         scenario_id = result["scenario_id"]

--- a/scenario_lab/runners/async_executor.py
+++ b/scenario_lab/runners/async_executor.py
@@ -37,7 +37,7 @@ class AsyncExecutor:
         self,
         scenario_path: str,
         output_path: Optional[str] = None,
-        max_turns: Optional[int] = None,
+        end_turn: Optional[int] = None,
         credit_limit: Optional[float] = None,
         json_mode: bool = False,
         log_level: str = "INFO",
@@ -48,14 +48,14 @@ class AsyncExecutor:
         Args:
             scenario_path: Path to scenario directory
             output_path: Path to output directory
-            max_turns: Maximum number of turns to execute
+            end_turn: Number of turns to execute (e.g., end_turn=5 executes 5 actor decision rounds)
             credit_limit: Maximum cost in USD
             json_mode: Whether to use JSON response format for actors
             log_level: Logging level (DEBUG, INFO, WARNING, ERROR)
         """
         self.scenario_path = scenario_path
         self.output_path = output_path
-        self.max_turns = max_turns
+        self.end_turn = end_turn
         self.credit_limit = credit_limit
         self.json_mode = json_mode
 
@@ -84,7 +84,7 @@ class AsyncExecutor:
         self.sync_runner = SyncRunner(
             scenario_path=self.scenario_path,
             output_path=self.output_path,
-            end_turn=self.max_turns,  # SyncRunner uses end_turn, AsyncExecutor uses max_turns
+            end_turn=self.end_turn,
             credit_limit=self.credit_limit,
             json_mode=self.json_mode,
         )
@@ -298,7 +298,7 @@ class AsyncExecutor:
 async def run_scenario_async(
     scenario_path: str,
     output_path: Optional[str] = None,
-    max_turns: Optional[int] = None,
+    end_turn: Optional[int] = None,
     credit_limit: Optional[float] = None,
     json_mode: bool = False,
 ) -> ScenarioState:
@@ -308,7 +308,7 @@ async def run_scenario_async(
     Args:
         scenario_path: Path to scenario directory
         output_path: Path to output directory
-        max_turns: Maximum number of turns
+        end_turn: Number of turns to execute
         credit_limit: Maximum cost in USD
         json_mode: Whether to use JSON response format
 
@@ -318,7 +318,7 @@ async def run_scenario_async(
     executor = AsyncExecutor(
         scenario_path=scenario_path,
         output_path=output_path,
-        max_turns=max_turns,
+        end_turn=end_turn,
         credit_limit=credit_limit,
         json_mode=json_mode,
     )

--- a/scenario_lab/tests/test_orchestrator.py
+++ b/scenario_lab/tests/test_orchestrator.py
@@ -53,10 +53,10 @@ class TestScenarioOrchestrator:
     def test_creation(self):
         """Test creating an orchestrator"""
         bus = EventBus()
-        orchestrator = ScenarioOrchestrator(event_bus=bus, max_turns=10)
+        orchestrator = ScenarioOrchestrator(event_bus=bus, end_turn=10)
 
         assert orchestrator.event_bus is bus
-        assert orchestrator.max_turns == 10
+        assert orchestrator.end_turn == 10
         assert len(orchestrator.phases) == 0
 
     def test_phase_registration(self):
@@ -97,9 +97,9 @@ class TestScenarioOrchestrator:
         assert EventType.TURN_COMPLETED in event_types
 
     @pytest.mark.asyncio
-    async def test_max_turns_respected(self):
-        """Test that max_turns stops execution"""
-        orchestrator = ScenarioOrchestrator(max_turns=3)
+    async def test_end_turn_respected(self):
+        """Test that end_turn stops execution"""
+        orchestrator = ScenarioOrchestrator(end_turn=3)
         orchestrator.register_phase(PhaseType.DECISION, MockPhase("decision"))
 
         state = ScenarioState(

--- a/scenario_lab/utils/cost_estimator.py
+++ b/scenario_lab/utils/cost_estimator.py
@@ -113,12 +113,12 @@ class CostEstimator:
 
         return True
 
-    def estimate(self, max_turns: Optional[int] = None) -> CostEstimate:
+    def estimate(self, end_turn: Optional[int] = None) -> CostEstimate:
         """
         Estimate costs for scenario execution
 
         Args:
-            max_turns: Override number of turns (uses scenario default if None)
+            end_turn: Override number of turns to execute (uses scenario default if None)
 
         Returns:
             CostEstimate with detailed breakdown
@@ -137,7 +137,7 @@ class CostEstimator:
                 )
 
         # Determine number of turns
-        turns = max_turns or self.scenario_config.turns or 10
+        turns = end_turn or self.scenario_config.turns or 10
 
         # Estimate per-actor costs
         actor_costs = {}

--- a/tests/test_async_executor.py
+++ b/tests/test_async_executor.py
@@ -69,7 +69,7 @@ class TestAsyncExecutor:
         """Test that executor initializes correctly"""
         executor = AsyncExecutor(
             scenario_path=str(temp_scenario_dir / "definition"),
-            max_turns=2,
+            end_turn=2,
             credit_limit=1.0,
         )
 
@@ -93,7 +93,7 @@ class TestAsyncExecutor:
         """Test pause and resume functionality"""
         executor = AsyncExecutor(
             scenario_path=str(temp_scenario_dir / "definition"),
-            max_turns=2,
+            end_turn=2,
         )
 
         await executor.setup()
@@ -116,7 +116,7 @@ class TestAsyncExecutor:
         """Test stop functionality"""
         executor = AsyncExecutor(
             scenario_path=str(temp_scenario_dir / "definition"),
-            max_turns=2,
+            end_turn=2,
         )
 
         await executor.setup()
@@ -144,7 +144,7 @@ class TestAsyncExecutor:
             # Run scenario
             final_state = await run_scenario_async(
                 scenario_path=str(temp_scenario_dir / "definition"),
-                max_turns=3,
+                end_turn=3,
             )
 
             # Verify execute was called
@@ -156,7 +156,7 @@ class TestAsyncExecutor:
         """Test that event streaming yields events"""
         executor = AsyncExecutor(
             scenario_path=str(temp_scenario_dir / "definition"),
-            max_turns=1,
+            end_turn=1,
         )
 
         await executor.setup()
@@ -197,7 +197,7 @@ class TestAsyncExecutor:
         """Test that executor handles execution failures"""
         executor = AsyncExecutor(
             scenario_path=str(temp_scenario_dir / "definition"),
-            max_turns=1,
+            end_turn=1,
         )
 
         await executor.setup()
@@ -219,7 +219,7 @@ class TestAsyncExecutor:
         """Test that executing without setup raises error"""
         executor = AsyncExecutor(
             scenario_path="/nonexistent/path",
-            max_turns=1,
+            end_turn=1,
         )
 
         # Should raise error if execute called without setup
@@ -233,7 +233,7 @@ class TestAsyncExecutor:
 
         executor = AsyncExecutor(
             scenario_path=str(temp_scenario_dir / "definition"),
-            max_turns=1,
+            end_turn=1,
         )
 
         await executor.setup()

--- a/web/README.md
+++ b/web/README.md
@@ -134,7 +134,7 @@ curl -X POST "http://localhost:8000/api/scenario/start" \
   -H "Content-Type: application/json" \
   -d '{
     "scenario_path": "scenarios/ai-summit-4actors",
-    "max_turns": 5
+    "end_turn": 5
   }'
 ```
 

--- a/web/frontend/src/api/client.ts
+++ b/web/frontend/src/api/client.ts
@@ -26,7 +26,7 @@ export interface V2RunSummary {
 
 export interface V2ScenarioExecuteRequest {
   scenario_path: string
-  max_turns?: number
+  end_turn?: number
   credit_limit?: number
   output_path?: string
   enable_database?: boolean


### PR DESCRIPTION
The ScenarioOrchestrator.__init__ was updated to use end_turn but callers and tests still used max_turns, causing TypeError failures.

Updated all occurrences to use end_turn consistently:
- scenario_lab/tests/test_orchestrator.py
- scenario_lab/runners/async_executor.py
- tests/test_async_executor.py
- scenario_lab/utils/cost_estimator.py
- docs/API.md
- docs/DATABASE_ANALYTICS_GUIDE.md
- web/README.md
- web/frontend/src/api/client.ts
- examples/api_client.py