### PR TITLE
Fix issue 36

### DIFF
--- a/scenarios/example-minimal-template/actors/gardening-club.yaml
+++ b/scenarios/example-minimal-template/actors/gardening-club.yaml
@@ -1,5 +1,5 @@
 name: "Community Gardening Club (Representative: Robert Chen)"
-short_name: "gardeners"
+short_name: "gardening-club"
 
 llm_model: "openai/gpt-4o-mini"
 

--- a/scenarios/example-minimal-template/actors/parent-representative.yaml
+++ b/scenarios/example-minimal-template/actors/parent-representative.yaml
@@ -1,5 +1,5 @@
 name: "Parents' Group Representative (Anna Martinez)"
-short_name: "parents"
+short_name: "parent-representative"
 
 llm_model: "openai/gpt-4o-mini"
 


### PR DESCRIPTION
The minimal template scenario violated schema rules where actor filenames must match their declared short_name values. Updated both actors:
- parent-representative.yaml: "parents" -> "parent-representative"
- gardening-club.yaml: "gardeners" -> "gardening-club"