### PR TITLE
Fix issue 55

### DIFF
--- a/scenario_lab/batch/batch_progress_tracker.py
+++ b/scenario_lab/batch/batch_progress_tracker.py
@@ -12,6 +12,8 @@ V2 Design:
 - Graceful degradation without rich library
 - Works with V2 batch components
 """
+from __future__ import annotations
+
 import time
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any


### PR DESCRIPTION
Added `from __future__ import annotations` to defer type annotation evaluation. This prevents NameError when `rich` library is not installed, since the `Layout` type annotation in `_generate_display()` would otherwise fail at import time when Layout is undefined.