### PR TITLE
Fix issue 71

### DIFF
--- a/scenario_lab/api/__init__.py
+++ b/scenario_lab/api/__init__.py
@@ -1,5 +1,24 @@
 """FastAPI web API for Scenario Lab V2"""
 
 from scenario_lab.api.app import app
+from scenario_lab.api.settings import APISettings, get_settings, reset_settings
+from scenario_lab.api.auth import verify_api_key, optional_api_key
+from scenario_lab.api.rate_limit import (
+    RateLimiter,
+    get_rate_limiter,
+    reset_rate_limiter,
+    check_rate_limit,
+)
 
-__all__ = ["app"]
+__all__ = [
+    "app",
+    "APISettings",
+    "get_settings",
+    "reset_settings",
+    "verify_api_key",
+    "optional_api_key",
+    "RateLimiter",
+    "get_rate_limiter",
+    "reset_rate_limiter",
+    "check_rate_limit",
+]

--- a/scenario_lab/api/auth.py
+++ b/scenario_lab/api/auth.py
@@ -1,0 +1,102 @@
+"""
+API Authentication for Scenario Lab
+
+Provides API key authentication via X-API-Key header.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+from scenario_lab.api.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+# API key header scheme
+api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def verify_api_key(
+    api_key: Optional[str] = Security(api_key_header),
+) -> Optional[str]:
+    """
+    Verify the API key from the X-API-Key header.
+
+    This dependency can be used on routes that require authentication.
+    When dev_mode is enabled or auth is disabled, authentication is bypassed.
+
+    Args:
+        api_key: The API key from the X-API-Key header
+
+    Returns:
+        The validated API key
+
+    Raises:
+        HTTPException: If authentication fails
+    """
+    settings = get_settings()
+
+    # Skip authentication if not required
+    if not settings.is_auth_required():
+        logger.debug("Authentication bypassed (dev_mode or auth disabled)")
+        return None
+
+    # Check if API key is provided
+    if not api_key:
+        logger.warning("API request without API key")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key. Provide X-API-Key header.",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
+
+    # Validate the API key
+    if not settings.validate_api_key(api_key):
+        logger.warning(f"Invalid API key attempt: {api_key[:8]}...")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
+
+    logger.debug("API key validated successfully")
+    return api_key
+
+
+async def optional_api_key(
+    api_key: Optional[str] = Security(api_key_header),
+) -> Optional[str]:
+    """
+    Optional API key verification for endpoints that work with or without auth.
+
+    Unlike verify_api_key, this doesn't raise an exception if no key is provided.
+    It only validates if a key IS provided.
+
+    Args:
+        api_key: The API key from the X-API-Key header
+
+    Returns:
+        The validated API key or None
+
+    Raises:
+        HTTPException: Only if an invalid key is provided
+    """
+    settings = get_settings()
+
+    # No key provided - that's okay for optional auth
+    if not api_key:
+        return None
+
+    # Key provided - validate it if auth is enabled
+    if settings.auth_enabled and not settings.validate_api_key(api_key):
+        logger.warning(f"Invalid API key attempt: {api_key[:8]}...")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid API key",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
+
+    return api_key

--- a/scenario_lab/api/rate_limit.py
+++ b/scenario_lab/api/rate_limit.py
@@ -1,0 +1,188 @@
+"""
+Rate Limiting for Scenario Lab API
+
+Provides configurable rate limiting using an in-memory sliding window approach.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Optional
+
+from fastapi import HTTPException, Request, status
+
+from scenario_lab.api.settings import get_settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RateLimitState:
+    """Track request timestamps for a single client."""
+
+    timestamps: list[float] = field(default_factory=list)
+
+
+class RateLimiter:
+    """
+    In-memory rate limiter using sliding window algorithm.
+
+    Tracks requests per client (identified by IP or API key) and enforces
+    configurable rate limits.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the rate limiter."""
+        self._clients: dict[str, RateLimitState] = defaultdict(RateLimitState)
+
+    def _get_client_id(self, request: Request, api_key: Optional[str] = None) -> str:
+        """
+        Get a unique identifier for the client.
+
+        Uses API key if available, otherwise falls back to IP address.
+
+        Args:
+            request: The FastAPI request
+            api_key: Optional API key
+
+        Returns:
+            Client identifier string
+        """
+        if api_key:
+            return f"key:{api_key[:16]}"
+
+        # Get client IP (handle proxies via X-Forwarded-For)
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            # Take the first IP in the chain (original client)
+            client_ip = forwarded.split(",")[0].strip()
+        else:
+            client_ip = request.client.host if request.client else "unknown"
+
+        return f"ip:{client_ip}"
+
+    def _cleanup_old_timestamps(
+        self, state: RateLimitState, window_seconds: int
+    ) -> None:
+        """
+        Remove timestamps older than the current window.
+
+        Args:
+            state: The rate limit state to clean
+            window_seconds: The window size in seconds
+        """
+        cutoff = time.time() - window_seconds
+        state.timestamps = [ts for ts in state.timestamps if ts > cutoff]
+
+    def check_rate_limit(
+        self,
+        request: Request,
+        api_key: Optional[str] = None,
+    ) -> tuple[bool, int, int]:
+        """
+        Check if a request is within rate limits.
+
+        Args:
+            request: The FastAPI request
+            api_key: Optional API key for client identification
+
+        Returns:
+            Tuple of (allowed, remaining, reset_seconds)
+        """
+        settings = get_settings()
+
+        # Rate limiting disabled
+        if not settings.rate_limit_enabled or settings.dev_mode:
+            return True, settings.rate_limit_requests, 0
+
+        client_id = self._get_client_id(request, api_key)
+        state = self._clients[client_id]
+
+        # Clean up old timestamps
+        self._cleanup_old_timestamps(state, settings.rate_limit_window)
+
+        # Check if limit exceeded
+        current_count = len(state.timestamps)
+        remaining = max(0, settings.rate_limit_requests - current_count)
+
+        if current_count >= settings.rate_limit_requests:
+            # Calculate reset time
+            if state.timestamps:
+                oldest = min(state.timestamps)
+                reset_seconds = int(settings.rate_limit_window - (time.time() - oldest))
+            else:
+                reset_seconds = settings.rate_limit_window
+
+            logger.warning(f"Rate limit exceeded for client {client_id}")
+            return False, 0, max(1, reset_seconds)
+
+        # Record this request
+        state.timestamps.append(time.time())
+
+        return True, remaining - 1, 0
+
+    def reset(self) -> None:
+        """Reset all rate limit state (useful for testing)."""
+        self._clients.clear()
+
+
+# Global rate limiter instance
+_rate_limiter: Optional[RateLimiter] = None
+
+
+def get_rate_limiter() -> RateLimiter:
+    """
+    Get the global rate limiter instance.
+
+    Returns:
+        RateLimiter instance
+    """
+    global _rate_limiter
+    if _rate_limiter is None:
+        _rate_limiter = RateLimiter()
+    return _rate_limiter
+
+
+def reset_rate_limiter() -> None:
+    """Reset the rate limiter (useful for testing)."""
+    global _rate_limiter
+    if _rate_limiter:
+        _rate_limiter.reset()
+    _rate_limiter = None
+
+
+async def check_rate_limit(
+    request: Request,
+    api_key: Optional[str] = None,
+) -> None:
+    """
+    FastAPI dependency to check rate limits.
+
+    Raises HTTPException with 429 status if rate limit is exceeded.
+
+    Args:
+        request: The FastAPI request
+        api_key: Optional API key for client identification
+
+    Raises:
+        HTTPException: If rate limit is exceeded
+    """
+    limiter = get_rate_limiter()
+    allowed, remaining, reset_seconds = limiter.check_rate_limit(request, api_key)
+
+    # Add rate limit headers to response
+    request.state.rate_limit_remaining = remaining
+    request.state.rate_limit_reset = reset_seconds
+
+    if not allowed:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Rate limit exceeded. Try again in {reset_seconds} seconds.",
+            headers={
+                "Retry-After": str(reset_seconds),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(reset_seconds),
+            },
+        )

--- a/scenario_lab/api/settings.py
+++ b/scenario_lab/api/settings.py
@@ -1,0 +1,131 @@
+"""
+API Settings for Scenario Lab
+
+Configuration for authentication, rate limiting, and other API settings.
+Settings are loaded from environment variables with sensible defaults.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class APISettings:
+    """
+    API configuration settings loaded from environment variables.
+
+    Environment Variables:
+        SCENARIO_LAB_API_KEY: Required API key for authentication (comma-separated for multiple keys)
+        SCENARIO_LAB_AUTH_ENABLED: Enable/disable authentication (default: true in production)
+        SCENARIO_LAB_RATE_LIMIT_ENABLED: Enable/disable rate limiting (default: true)
+        SCENARIO_LAB_RATE_LIMIT_REQUESTS: Max requests per window (default: 100)
+        SCENARIO_LAB_RATE_LIMIT_WINDOW: Time window in seconds (default: 60)
+        SCENARIO_LAB_DEV_MODE: Enable development mode with relaxed security (default: false)
+    """
+
+    # Authentication settings
+    api_keys: list[str] = field(default_factory=list)
+    auth_enabled: bool = True
+
+    # Rate limiting settings
+    rate_limit_enabled: bool = True
+    rate_limit_requests: int = 100  # requests per window
+    rate_limit_window: int = 60  # seconds
+
+    # Development mode (disables auth and rate limiting)
+    dev_mode: bool = False
+
+    @classmethod
+    def from_env(cls) -> "APISettings":
+        """
+        Load settings from environment variables.
+
+        Returns:
+            APISettings instance configured from environment
+        """
+        # Parse API keys (comma-separated)
+        api_keys_str = os.environ.get("SCENARIO_LAB_API_KEY", "")
+        api_keys = [k.strip() for k in api_keys_str.split(",") if k.strip()]
+
+        # Parse dev mode first (affects other defaults)
+        dev_mode = os.environ.get("SCENARIO_LAB_DEV_MODE", "false").lower() in (
+            "true",
+            "1",
+            "yes",
+        )
+
+        # Auth enabled: default to False if dev_mode or no keys configured
+        auth_enabled_default = "false" if (dev_mode or not api_keys) else "true"
+        auth_enabled = os.environ.get(
+            "SCENARIO_LAB_AUTH_ENABLED", auth_enabled_default
+        ).lower() in ("true", "1", "yes")
+
+        # Rate limiting: default to False in dev mode
+        rate_limit_enabled_default = "false" if dev_mode else "true"
+        rate_limit_enabled = os.environ.get(
+            "SCENARIO_LAB_RATE_LIMIT_ENABLED", rate_limit_enabled_default
+        ).lower() in ("true", "1", "yes")
+
+        # Rate limit configuration
+        rate_limit_requests = int(
+            os.environ.get("SCENARIO_LAB_RATE_LIMIT_REQUESTS", "100")
+        )
+        rate_limit_window = int(
+            os.environ.get("SCENARIO_LAB_RATE_LIMIT_WINDOW", "60")
+        )
+
+        return cls(
+            api_keys=api_keys,
+            auth_enabled=auth_enabled,
+            rate_limit_enabled=rate_limit_enabled,
+            rate_limit_requests=rate_limit_requests,
+            rate_limit_window=rate_limit_window,
+            dev_mode=dev_mode,
+        )
+
+    def validate_api_key(self, key: Optional[str]) -> bool:
+        """
+        Validate an API key.
+
+        Args:
+            key: The API key to validate
+
+        Returns:
+            True if the key is valid, False otherwise
+        """
+        if not self.auth_enabled:
+            return True
+        if not key:
+            return False
+        return key in self.api_keys
+
+    def is_auth_required(self) -> bool:
+        """Check if authentication is required."""
+        return self.auth_enabled and not self.dev_mode
+
+
+# Global settings instance (lazy-loaded)
+_settings: Optional[APISettings] = None
+
+
+def get_settings() -> APISettings:
+    """
+    Get the global API settings instance.
+
+    Settings are loaded once from environment variables.
+
+    Returns:
+        APISettings instance
+    """
+    global _settings
+    if _settings is None:
+        _settings = APISettings.from_env()
+    return _settings
+
+
+def reset_settings() -> None:
+    """Reset settings (useful for testing)."""
+    global _settings
+    _settings = None

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,0 +1,511 @@
+"""
+Tests for API Authentication and Rate Limiting
+
+Tests for API key authentication, rate limiting, and configuration settings.
+"""
+import os
+import time
+import pytest
+from unittest.mock import patch, MagicMock, Mock
+from fastapi.testclient import TestClient
+
+from scenario_lab.api.settings import APISettings, get_settings, reset_settings
+from scenario_lab.api.auth import verify_api_key, optional_api_key
+from scenario_lab.api.rate_limit import (
+    RateLimiter,
+    get_rate_limiter,
+    reset_rate_limiter,
+)
+
+
+class TestAPISettings:
+    """Tests for APISettings configuration"""
+
+    def setup_method(self):
+        """Reset settings before each test"""
+        reset_settings()
+
+    def teardown_method(self):
+        """Clean up environment after each test"""
+        reset_settings()
+        # Clean up environment variables
+        for key in [
+            "SCENARIO_LAB_API_KEY",
+            "SCENARIO_LAB_AUTH_ENABLED",
+            "SCENARIO_LAB_RATE_LIMIT_ENABLED",
+            "SCENARIO_LAB_RATE_LIMIT_REQUESTS",
+            "SCENARIO_LAB_RATE_LIMIT_WINDOW",
+            "SCENARIO_LAB_DEV_MODE",
+        ]:
+            os.environ.pop(key, None)
+
+    def test_default_settings_no_keys(self):
+        """Test default settings with no API keys configured"""
+        settings = APISettings.from_env()
+
+        assert settings.api_keys == []
+        assert settings.auth_enabled is False  # No keys = auth disabled
+        assert settings.rate_limit_enabled is True
+        assert settings.rate_limit_requests == 100
+        assert settings.rate_limit_window == 60
+        assert settings.dev_mode is False
+
+    def test_settings_with_single_api_key(self):
+        """Test settings with a single API key"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "test-key-123"
+
+        settings = APISettings.from_env()
+
+        assert settings.api_keys == ["test-key-123"]
+        assert settings.auth_enabled is True
+
+    def test_settings_with_multiple_api_keys(self):
+        """Test settings with multiple API keys"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "key1, key2, key3"
+
+        settings = APISettings.from_env()
+
+        assert settings.api_keys == ["key1", "key2", "key3"]
+        assert len(settings.api_keys) == 3
+
+    def test_dev_mode_disables_auth_and_rate_limit(self):
+        """Test that dev mode disables auth and rate limiting"""
+        os.environ["SCENARIO_LAB_DEV_MODE"] = "true"
+        os.environ["SCENARIO_LAB_API_KEY"] = "test-key"
+
+        settings = APISettings.from_env()
+
+        assert settings.dev_mode is True
+        assert settings.auth_enabled is False
+        assert settings.rate_limit_enabled is False
+
+    def test_custom_rate_limit_settings(self):
+        """Test custom rate limit settings"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "50"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_WINDOW"] = "30"
+
+        settings = APISettings.from_env()
+
+        assert settings.rate_limit_requests == 50
+        assert settings.rate_limit_window == 30
+
+    def test_explicit_auth_override(self):
+        """Test explicit auth enabled/disabled override"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "test-key"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "false"
+
+        settings = APISettings.from_env()
+
+        assert settings.auth_enabled is False
+        assert settings.api_keys == ["test-key"]  # Key is still stored
+
+    def test_validate_api_key_valid(self):
+        """Test API key validation with valid key"""
+        settings = APISettings(
+            api_keys=["valid-key-1", "valid-key-2"],
+            auth_enabled=True,
+        )
+
+        assert settings.validate_api_key("valid-key-1") is True
+        assert settings.validate_api_key("valid-key-2") is True
+
+    def test_validate_api_key_invalid(self):
+        """Test API key validation with invalid key"""
+        settings = APISettings(
+            api_keys=["valid-key"],
+            auth_enabled=True,
+        )
+
+        assert settings.validate_api_key("invalid-key") is False
+        assert settings.validate_api_key("") is False
+        assert settings.validate_api_key(None) is False
+
+    def test_validate_api_key_auth_disabled(self):
+        """Test that any key passes when auth is disabled"""
+        settings = APISettings(
+            api_keys=["valid-key"],
+            auth_enabled=False,
+        )
+
+        assert settings.validate_api_key("any-key") is True
+        assert settings.validate_api_key(None) is True
+
+    def test_is_auth_required(self):
+        """Test is_auth_required method"""
+        # Auth required
+        settings = APISettings(api_keys=["key"], auth_enabled=True, dev_mode=False)
+        assert settings.is_auth_required() is True
+
+        # Auth disabled
+        settings = APISettings(api_keys=["key"], auth_enabled=False, dev_mode=False)
+        assert settings.is_auth_required() is False
+
+        # Dev mode
+        settings = APISettings(api_keys=["key"], auth_enabled=True, dev_mode=True)
+        assert settings.is_auth_required() is False
+
+    def test_get_settings_singleton(self):
+        """Test that get_settings returns same instance"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "test-key"
+
+        settings1 = get_settings()
+        settings2 = get_settings()
+
+        assert settings1 is settings2
+
+
+class TestRateLimiter:
+    """Tests for RateLimiter class"""
+
+    def setup_method(self):
+        """Reset rate limiter before each test"""
+        reset_rate_limiter()
+        reset_settings()
+
+    def teardown_method(self):
+        """Clean up after each test"""
+        reset_rate_limiter()
+        reset_settings()
+        for key in [
+            "SCENARIO_LAB_API_KEY",
+            "SCENARIO_LAB_RATE_LIMIT_ENABLED",
+            "SCENARIO_LAB_RATE_LIMIT_REQUESTS",
+            "SCENARIO_LAB_RATE_LIMIT_WINDOW",
+            "SCENARIO_LAB_DEV_MODE",
+        ]:
+            os.environ.pop(key, None)
+
+    def test_rate_limiter_allows_requests_under_limit(self):
+        """Test that requests under the limit are allowed"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "5"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_WINDOW"] = "60"
+
+        limiter = RateLimiter()
+        mock_request = Mock()
+        mock_request.headers = {}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"
+
+        # First 5 requests should be allowed
+        for i in range(5):
+            allowed, remaining, reset = limiter.check_rate_limit(mock_request)
+            assert allowed is True
+            assert remaining == 4 - i
+
+    def test_rate_limiter_blocks_requests_over_limit(self):
+        """Test that requests over the limit are blocked"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "3"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_WINDOW"] = "60"
+
+        limiter = RateLimiter()
+        mock_request = Mock()
+        mock_request.headers = {}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"
+
+        # Make 3 requests (at limit)
+        for _ in range(3):
+            allowed, _, _ = limiter.check_rate_limit(mock_request)
+            assert allowed is True
+
+        # 4th request should be blocked
+        allowed, remaining, reset = limiter.check_rate_limit(mock_request)
+        assert allowed is False
+        assert remaining == 0
+        assert reset > 0
+
+    def test_rate_limiter_tracks_by_ip(self):
+        """Test that rate limits are tracked per IP"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "2"
+
+        limiter = RateLimiter()
+
+        # Client 1
+        mock_request_1 = Mock()
+        mock_request_1.headers = {}
+        mock_request_1.client = Mock()
+        mock_request_1.client.host = "192.168.1.1"
+
+        # Client 2
+        mock_request_2 = Mock()
+        mock_request_2.headers = {}
+        mock_request_2.client = Mock()
+        mock_request_2.client.host = "192.168.1.2"
+
+        # Client 1 makes 2 requests
+        limiter.check_rate_limit(mock_request_1)
+        limiter.check_rate_limit(mock_request_1)
+
+        # Client 1 should be blocked
+        allowed, _, _ = limiter.check_rate_limit(mock_request_1)
+        assert allowed is False
+
+        # Client 2 should still be allowed
+        allowed, _, _ = limiter.check_rate_limit(mock_request_2)
+        assert allowed is True
+
+    def test_rate_limiter_tracks_by_api_key(self):
+        """Test that rate limits are tracked per API key"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "2"
+
+        limiter = RateLimiter()
+
+        mock_request = Mock()
+        mock_request.headers = {}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"
+
+        # API key 1 makes 2 requests
+        limiter.check_rate_limit(mock_request, api_key="key-1")
+        limiter.check_rate_limit(mock_request, api_key="key-1")
+
+        # API key 1 should be blocked
+        allowed, _, _ = limiter.check_rate_limit(mock_request, api_key="key-1")
+        assert allowed is False
+
+        # API key 2 should still be allowed
+        allowed, _, _ = limiter.check_rate_limit(mock_request, api_key="key-2")
+        assert allowed is True
+
+    def test_rate_limiter_respects_x_forwarded_for(self):
+        """Test that X-Forwarded-For header is used for client identification"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "2"
+
+        limiter = RateLimiter()
+
+        mock_request = Mock()
+        mock_request.headers = {"X-Forwarded-For": "10.0.0.1, 192.168.1.1"}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"  # Proxy IP
+
+        # Make 2 requests
+        limiter.check_rate_limit(mock_request)
+        limiter.check_rate_limit(mock_request)
+
+        # Should be blocked based on forwarded IP
+        allowed, _, _ = limiter.check_rate_limit(mock_request)
+        assert allowed is False
+
+    def test_rate_limiter_disabled_in_dev_mode(self):
+        """Test that rate limiting is disabled in dev mode"""
+        os.environ["SCENARIO_LAB_DEV_MODE"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "1"
+
+        limiter = RateLimiter()
+
+        mock_request = Mock()
+        mock_request.headers = {}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"
+
+        # Should allow many requests in dev mode
+        for _ in range(10):
+            allowed, _, _ = limiter.check_rate_limit(mock_request)
+            assert allowed is True
+
+    def test_rate_limiter_window_sliding(self):
+        """Test that old requests expire from the window"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "2"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_WINDOW"] = "1"  # 1 second window
+
+        limiter = RateLimiter()
+
+        mock_request = Mock()
+        mock_request.headers = {}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"
+
+        # Make 2 requests (at limit)
+        limiter.check_rate_limit(mock_request)
+        limiter.check_rate_limit(mock_request)
+
+        # 3rd request should be blocked
+        allowed, _, _ = limiter.check_rate_limit(mock_request)
+        assert allowed is False
+
+        # Wait for window to expire
+        time.sleep(1.1)
+
+        # Should be allowed again
+        allowed, _, _ = limiter.check_rate_limit(mock_request)
+        assert allowed is True
+
+    def test_reset_clears_state(self):
+        """Test that reset clears all rate limit state"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "1"
+
+        limiter = RateLimiter()
+
+        mock_request = Mock()
+        mock_request.headers = {}
+        mock_request.client = Mock()
+        mock_request.client.host = "127.0.0.1"
+
+        # Make 1 request (at limit)
+        limiter.check_rate_limit(mock_request)
+
+        # Should be blocked
+        allowed, _, _ = limiter.check_rate_limit(mock_request)
+        assert allowed is False
+
+        # Reset
+        limiter.reset()
+
+        # Should be allowed again
+        allowed, _, _ = limiter.check_rate_limit(mock_request)
+        assert allowed is True
+
+
+class TestAPIEndpointsAuth:
+    """Integration tests for API authentication on endpoints"""
+
+    def setup_method(self):
+        """Reset state before each test"""
+        reset_settings()
+        reset_rate_limiter()
+
+    def teardown_method(self):
+        """Clean up after each test"""
+        reset_settings()
+        reset_rate_limiter()
+        for key in [
+            "SCENARIO_LAB_API_KEY",
+            "SCENARIO_LAB_AUTH_ENABLED",
+            "SCENARIO_LAB_DEV_MODE",
+            "SCENARIO_LAB_RATE_LIMIT_ENABLED",
+        ]:
+            os.environ.pop(key, None)
+
+    def test_health_endpoint_no_auth_required(self):
+        """Test that health endpoint doesn't require auth"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "secret-key"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "true"
+
+        # Import app after setting env vars
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "auth_enabled" in data
+
+    def test_root_endpoint_no_auth_required(self):
+        """Test that root endpoint doesn't require auth"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "secret-key"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "true"
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        response = client.get("/")
+        assert response.status_code == 200
+
+    def test_protected_endpoint_requires_auth(self):
+        """Test that protected endpoints require auth when enabled"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "secret-key"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "false"  # Disable rate limiting for this test
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        # Request without API key should fail
+        response = client.get("/api/runs")
+        assert response.status_code == 401
+        assert "Missing API key" in response.json()["detail"]
+
+    def test_protected_endpoint_with_valid_key(self):
+        """Test that protected endpoints work with valid API key"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "secret-key"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "false"
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        response = client.get(
+            "/api/runs",
+            headers={"X-API-Key": "secret-key"}
+        )
+        # Will be 503 because database is not configured in tests, but not 401
+        assert response.status_code == 503  # Database not configured
+        assert "Database not configured" in response.json()["detail"]
+
+    def test_protected_endpoint_with_invalid_key(self):
+        """Test that protected endpoints reject invalid API key"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "secret-key"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "false"
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        response = client.get(
+            "/api/runs",
+            headers={"X-API-Key": "wrong-key"}
+        )
+        assert response.status_code == 401
+        assert "Invalid API key" in response.json()["detail"]
+
+    def test_dev_mode_bypasses_auth(self):
+        """Test that dev mode bypasses authentication"""
+        os.environ["SCENARIO_LAB_API_KEY"] = "secret-key"
+        os.environ["SCENARIO_LAB_DEV_MODE"] = "true"
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        # Should work without API key in dev mode
+        response = client.get("/api/runs")
+        # Will be 503 because database is not configured, but not 401
+        assert response.status_code == 503
+
+    def test_rate_limit_headers_present(self):
+        """Test that rate limit headers are included in response"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "100"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "false"
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        response = client.get("/api/runs")
+        # Check rate limit headers
+        assert "X-RateLimit-Limit" in response.headers
+        assert "X-RateLimit-Remaining" in response.headers
+
+    def test_rate_limit_exceeded_returns_429(self):
+        """Test that exceeding rate limit returns 429"""
+        os.environ["SCENARIO_LAB_RATE_LIMIT_ENABLED"] = "true"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_REQUESTS"] = "2"
+        os.environ["SCENARIO_LAB_RATE_LIMIT_WINDOW"] = "60"
+        os.environ["SCENARIO_LAB_AUTH_ENABLED"] = "false"
+
+        from scenario_lab.api.app import app
+
+        client = TestClient(app)
+
+        # Make requests up to limit
+        client.get("/api/runs")
+        client.get("/api/runs")
+
+        # Next request should be rate limited
+        response = client.get("/api/runs")
+        assert response.status_code == 429
+        assert "Retry-After" in response.headers


### PR DESCRIPTION
- Add API key authentication via X-API-Key header
- Implement configurable rate limiting with sliding window algorithm
- Add development mode to bypass auth and rate limiting for local testing
- Support multiple API keys (comma-separated)
- Track rate limits per client (by API key or IP address)
- Add rate limit headers (X-RateLimit-Limit, X-RateLimit-Remaining)
- Skip auth/rate limiting on health, root, and docs endpoints
- Comprehensive test suite (27 tests) for auth and rate limiting

Configuration via environment variables:
- SCENARIO_LAB_API_KEY: API key(s) for authentication
- SCENARIO_LAB_AUTH_ENABLED: Enable/disable authentication
- SCENARIO_LAB_RATE_LIMIT_ENABLED: Enable/disable rate limiting
- SCENARIO_LAB_RATE_LIMIT_REQUESTS: Max requests per window (default: 100)
- SCENARIO_LAB_RATE_LIMIT_WINDOW: Time window in seconds (default: 60)
- SCENARIO_LAB_DEV_MODE: Development mode (disables auth and rate limiting)