### PR TITLE
Fix issue 40 and validate correctness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ actors:
 
 **Validation rules:**
 - `turn_duration` must match pattern: `^\d+\s+(second|minute|hour|day|week|month|year)s?$`
-- Actor names must be lowercase with hyphens (e.g., "us-president", not "US President")
+- Actor names are normalized to lowercase with hyphens (e.g., "CCP" → "ccp", "EU" → "eu")
 - At least one actor required
 
 ---
@@ -132,7 +132,7 @@ Each actor needs a separate file in the `actors/` directory. Filename must match
 | Field | Type | Description |
 |-------|------|-------------|
 | `name` | string | Actor display name |
-| `short_name` | string | Identifier (lowercase-with-hyphens) |
+| `short_name` | string | Identifier (auto-normalized to lowercase-with-hyphens) |
 
 **Recommended fields:**
 
@@ -516,8 +516,8 @@ scenario-lab run scenarios/your-scenario --dry-run
 
 Before running, verify:
 
-1. **All actor files exist** - Each name in `actors:` list needs a matching `.yaml` file
-2. **Actor names are lowercase-with-hyphens** - e.g., "us-president" not "US President"
+1. **All actor files exist** - Each name in `actors:` list needs a matching `.yaml` file (lowercase)
+2. **Actor names contain only valid characters** - Letters, numbers, and hyphens (uppercase is auto-normalized)
 3. **Turn duration format is correct** - e.g., "1 week" not "1 wk" or "weekly"
 4. **Metrics reference valid extraction types** - "pattern", "keyword", "llm", or "manual"
 5. **Model names are valid** - Use "provider/model" format
@@ -526,9 +526,9 @@ Before running, verify:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| "Actor file not found" | Missing YAML file | Create actors/[name].yaml |
+| "Actor file not found" | Missing YAML file | Create actors/[name].yaml (use lowercase filename) |
 | "Invalid turn_duration" | Wrong format | Use "N unit" format |
-| "Invalid actor name" | Uppercase or spaces | Use lowercase-with-hyphens |
+| "Invalid actor name" | Spaces or special characters | Use only letters, numbers, and hyphens |
 | "'range' required" | Missing for continuous metric | Add range: [min, max] |
 | "'prompt' required" | Missing for LLM extraction | Add prompt field |
 

--- a/docs/ARCHITECTURE_GROUND_TRUTH.md
+++ b/docs/ARCHITECTURE_GROUND_TRUTH.md
@@ -372,7 +372,7 @@ parallel_action_resolution: true
 ```yaml
 # REQUIRED
 name: "Full Actor Name"           # Display name
-short_name: actor-id              # Identifier (lowercase, hyphens)
+short_name: actor-id              # Identifier (auto-normalized to lowercase)
 llm_model: "openai/gpt-4o"        # Or "model:"
 
 # BEHAVIOR

--- a/docs/scenario-creation-guide.md
+++ b/docs/scenario-creation-guide.md
@@ -222,9 +222,10 @@ information_access:
 
 ### Actor Naming Convention
 
-- Use lowercase with hyphens: `government-official` (not `Government Official`)
-- Filename must match `short_name`: `actors/government-official.yaml`
-- Reference in scenario.yaml must match: `actors: [government-official]`
+- Actor names are auto-normalized to lowercase: `CCP` → `ccp`, `EU` → `eu`
+- Use letters, numbers, and hyphens only (no spaces or special characters)
+- Filename must match the normalized `short_name`: `actors/ccp.yaml`
+- Reference in scenario.yaml is auto-normalized: `actors: [CCP]` becomes `actors: [ccp]`
 
 ### Model Selection
 
@@ -256,9 +257,9 @@ This checks:
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| "Actor file not found" | Missing YAML file | Create `actors/[name].yaml` |
+| "Actor file not found" | Missing YAML file | Create `actors/[name].yaml` (use lowercase filename) |
 | "Invalid turn_duration" | Wrong format | Use "N unit" format (e.g., "1 week") |
-| "Invalid actor name" | Uppercase or spaces | Use lowercase-with-hyphens |
+| "Invalid actor name" | Spaces or special characters | Use only letters, numbers, and hyphens |
 
 ---
 

--- a/scenario_lab/schemas/actor.py
+++ b/scenario_lab/schemas/actor.py
@@ -46,9 +46,35 @@ class ActorConfig(BaseModel):
 
     short_name: str = Field(
         ...,
-        description="Actor identifier used in filenames (lowercase, hyphens)",
-        pattern=r"^[a-z0-9-]+$",
+        description="Actor identifier used in filenames (lowercase, hyphens). "
+                    "Uppercase input is automatically converted to lowercase.",
     )
+
+    @field_validator('short_name', mode='before')
+    @classmethod
+    def normalize_short_name(cls, v: str) -> str:
+        """Normalize short_name to lowercase and validate format.
+
+        Allows users to write 'CCP', 'EU', 'NATO' etc., which are
+        automatically converted to 'ccp', 'eu', 'nato'.
+        """
+        if not isinstance(v, str):
+            raise ValueError("short_name must be a string")
+
+        # Normalize to lowercase
+        normalized = v.lower()
+
+        # Validate format after normalization
+        if not all(c.islower() or c.isdigit() or c == '-' for c in normalized):
+            raise ValueError(
+                f"short_name '{v}' contains invalid characters. "
+                "Only letters, numbers, and hyphens are allowed."
+            )
+
+        if not normalized:
+            raise ValueError("short_name cannot be empty")
+
+        return normalized
 
     # Model configuration (support both field names)
     llm_model: Optional[str] = Field(

--- a/scenario_lab/schemas/scenario.py
+++ b/scenario_lab/schemas/scenario.py
@@ -193,25 +193,37 @@ class ScenarioConfig(BaseModel):
     @field_validator('actors')
     @classmethod
     def validate_actor_names(cls, v: List[str]) -> List[str]:
-        """Validate actor short names"""
+        """Validate and normalize actor short names.
+
+        Actor names are automatically converted to lowercase, allowing
+        users to write 'CCP', 'EU', 'NATO' etc.
+        """
         if not v:
             raise ValueError("At least one actor is required")
 
-        # Check for duplicates
-        if len(v) != len(set(v)):
-            raise ValueError("Duplicate actor names found")
-
-        # Validate format
+        # Normalize all names to lowercase
+        normalized = []
         for actor in v:
             if not actor or not actor.strip():
                 raise ValueError("Actor names cannot be empty")
-            # Should match lowercase-with-hyphens pattern
-            if not all(c.islower() or c.isdigit() or c == '-' for c in actor):
+
+            # Normalize to lowercase
+            actor_lower = actor.lower()
+
+            # Validate format after normalization
+            if not all(c.islower() or c.isdigit() or c == '-' for c in actor_lower):
                 raise ValueError(
-                    f"Actor name '{actor}' should be lowercase with hyphens (e.g., 'united-states')"
+                    f"Actor name '{actor}' contains invalid characters. "
+                    "Only letters, numbers, and hyphens are allowed."
                 )
 
-        return v
+            normalized.append(actor_lower)
+
+        # Check for duplicates (after normalization)
+        if len(normalized) != len(set(normalized)):
+            raise ValueError("Duplicate actor names found (after case normalization)")
+
+        return normalized
 
     @field_validator('turn_duration')
     @classmethod


### PR DESCRIPTION
Actor names like 'CCP', 'EU', 'NATO' are now automatically normalized to lowercase instead of being rejected with a validation error. This allows users to use more intuitive naming while maintaining internal consistency.

Changes:
- actor.py: Add field_validator for short_name that normalizes to lowercase
- scenario.py: Modify validate_actor_names to normalize instead of reject
- Update documentation to reflect the new behavior