### PR TITLE
Add real-time simulation updates to dashboard

### DIFF
--- a/scenario_lab/api/app.py
+++ b/scenario_lab/api/app.py
@@ -605,7 +605,7 @@ async def websocket_stream(websocket: WebSocket, scenario_id: str):
                 )
                 break
 
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.1)  # Reduced from 0.5s to 0.1s for faster updates
 
     except WebSocketDisconnect:
         logger.info(f"WebSocket disconnected for scenario {scenario_id}")

--- a/scenario_lab/runners/sync_runner.py
+++ b/scenario_lab/runners/sync_runner.py
@@ -218,6 +218,7 @@ class SyncRunner:
         # Communication phase (V2)
         communication_phase = CommunicationPhase(
             output_dir=self.output_path,
+            event_bus=self.event_bus,
         )
         self.orchestrator.register_phase(PhaseType.COMMUNICATION, communication_phase)
 
@@ -245,6 +246,7 @@ class SyncRunner:
             json_mode=self.json_mode,
             context_window_size=self.scenario_config.get("context_window", 3),
             metrics_tracker=self.metrics_tracker,
+            event_bus=self.event_bus,
         )
         self.orchestrator.register_phase(PhaseType.DECISION, decision_phase)
 
@@ -258,6 +260,7 @@ class SyncRunner:
             output_dir=self.output_path,
             metrics_tracker=self.metrics_tracker,
             qa_validator=self.qa_validator,
+            event_bus=self.event_bus,
         )
         self.orchestrator.register_phase(PhaseType.WORLD_UPDATE, world_update_phase)
 

--- a/scenario_lab/services/communication_phase.py
+++ b/scenario_lab/services/communication_phase.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 from scenario_lab.models.state import ScenarioState
 from scenario_lab.core.communication_manager import create_communication
+from scenario_lab.core.events import EventBus, EventType, get_event_bus
 
 logger = logging.getLogger(__name__)
 
@@ -39,14 +40,16 @@ class CommunicationPhaseV2:
     - Public statement prompts
     """
 
-    def __init__(self, output_dir: Optional[str] = None):
+    def __init__(self, output_dir: Optional[str] = None, event_bus: Optional[EventBus] = None):
         """
         Initialize communication phase
 
         Args:
             output_dir: Optional directory to export communication files
+            event_bus: Optional EventBus for emitting real-time events
         """
         self.output_dir = output_dir
+        self.event_bus = event_bus or get_event_bus()
 
     async def execute(self, state: ScenarioState) -> ScenarioState:
         """
@@ -75,7 +78,7 @@ class CommunicationPhaseV2:
         if turn_comms:
             logger.info(f"  Found {len(turn_comms)} communications for turn {state.turn}")
 
-            # Log details about each communication type
+            # Log details about each communication type and emit events
             for comm in turn_comms:
                 if comm.type == "coalition":
                     all_members = sorted(set([comm.sender] + comm.recipients))
@@ -96,6 +99,20 @@ class CommunicationPhaseV2:
                     if len(comm.content) > 30:
                         content_preview += "..."
                     logger.info(f"  ✓ Public statement by {comm.sender}: \"{content_preview}\"")
+
+                # Emit communication sent event with full content
+                await self.event_bus.emit(
+                    EventType.COMMUNICATION_SENT,
+                    data={
+                        "id": comm.id,
+                        "turn": comm.turn,
+                        "type": comm.type,
+                        "sender": comm.sender,
+                        "recipients": comm.recipients,
+                        "content": comm.content,
+                    },
+                    source="communication_phase",
+                )
 
             # Export to files if output_dir is set
             if self.output_dir:

--- a/scenario_lab/services/decision_phase_v2.py
+++ b/scenario_lab/services/decision_phase_v2.py
@@ -27,6 +27,7 @@ from scenario_lab.utils.response_parser import parse_decision
 from scenario_lab.utils.model_pricing import calculate_cost
 from scenario_lab.core.context_manager import ContextManagerV2
 from scenario_lab.core.communication_manager import format_communications_for_context
+from scenario_lab.core.events import EventBus, EventType, get_event_bus
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +54,7 @@ class DecisionPhaseV2:
         json_mode: bool = False,
         context_window_size: int = 3,
         metrics_tracker: Optional[Any] = None,  # MetricsTracker from Phase 3.3
+        event_bus: Optional[EventBus] = None,
     ):
         """
         Initialize decision phase
@@ -64,6 +66,7 @@ class DecisionPhaseV2:
             json_mode: Whether to use JSON response format (default: False)
             metrics_tracker: Optional MetricsTracker for metrics extraction
             context_window_size: Number of recent turns to keep in full detail (default: 3)
+            event_bus: Optional EventBus for emitting real-time events
         """
         self.actor_configs = actor_configs
         self.scenario_system_prompt = scenario_system_prompt
@@ -71,6 +74,7 @@ class DecisionPhaseV2:
         self.json_mode = json_mode
         self.api_key = os.environ.get('OPENROUTER_API_KEY')
         self.metrics_tracker = metrics_tracker  # Phase 3.3
+        self.event_bus = event_bus or get_event_bus()
 
         # Create context manager for windowing
         self.context_manager = ContextManagerV2(
@@ -98,6 +102,18 @@ class DecisionPhaseV2:
         for actor_short_name, actor_config in self.actor_configs.items():
             actor_name = actor_config['name']
             logger.debug(f"Getting decision from {actor_name}")
+
+            # Emit actor decision started event
+            await self.event_bus.emit(
+                EventType.ACTOR_DECISION_STARTED,
+                data={
+                    "actor": actor_name,
+                    "actor_short_name": actor_short_name,
+                    "turn": state.turn,
+                    "model": actor_config.get('llm_model', 'unknown'),
+                },
+                source="decision_phase",
+            )
 
             # Phase 2.1: Get contextualized world state for this actor
             current_world_state = await self.context_manager.get_context_for_actor(
@@ -200,6 +216,23 @@ class DecisionPhaseV2:
             logger.info(
                 f"  ✓ {actor_name}: {linked_preview} "
                 f"({llm_response.tokens_used:,} tokens, ${cost_amount:.4f})"
+            )
+
+            # Emit actor decision completed event with full content
+            await self.event_bus.emit(
+                EventType.ACTOR_DECISION_COMPLETED,
+                data={
+                    "actor": actor_name,
+                    "actor_short_name": actor_short_name,
+                    "turn": state.turn,
+                    "model": actor_config.get('llm_model', 'unknown'),
+                    "goals": decision.goals,
+                    "reasoning": decision.reasoning,
+                    "action": decision.action,
+                    "tokens_used": llm_response.tokens_used,
+                    "cost": cost_amount,
+                },
+                source="decision_phase",
             )
 
         # Phase 3.3: Extract metrics from all decisions after all actors have decided

--- a/scenario_lab/services/world_update_phase_v2.py
+++ b/scenario_lab/services/world_update_phase_v2.py
@@ -25,6 +25,7 @@ from scenario_lab.utils.api_client import make_llm_call_async, LLMResponse
 from scenario_lab.core.world_synthesizer import WorldSynthesizer, WorldUpdateResult
 from scenario_lab.core.prompt_builder import build_messages_for_llm
 from scenario_lab.utils.model_pricing import calculate_cost
+from scenario_lab.core.events import EventBus, EventType, get_event_bus
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ class WorldUpdatePhaseV2:
         output_dir: Optional[str] = None,
         metrics_tracker: Optional[Any] = None,  # MetricsTracker from Phase 3.3
         qa_validator: Optional[Any] = None,  # QAValidator from Phase 3.4
+        event_bus: Optional[EventBus] = None,
     ):
         """
         Initialize world update phase
@@ -60,6 +62,7 @@ class WorldUpdatePhaseV2:
             output_dir: Optional directory to save world state markdown files
             metrics_tracker: Optional MetricsTracker for metrics extraction
             qa_validator: Optional QAValidator for validation
+            event_bus: Optional EventBus for emitting real-time events
         """
         self.scenario_name = scenario_name
         self.world_state_model = world_state_model
@@ -67,6 +70,7 @@ class WorldUpdatePhaseV2:
         self.api_key = os.environ.get('OPENROUTER_API_KEY')
         self.metrics_tracker = metrics_tracker  # Phase 3.3
         self.qa_validator = qa_validator  # Phase 3.4
+        self.event_bus = event_bus or get_event_bus()
 
         # Create synthesizer
         self.synthesizer = WorldSynthesizer(
@@ -197,6 +201,20 @@ class WorldUpdatePhaseV2:
             f"({llm_response.tokens_used:,} tokens, ${cost_amount:.4f})"
         )
         logger.info(f"  ✓ {len(parsed['key_changes'])} key changes, {len(parsed['consequences'])} consequences")
+
+        # Emit world state updated event with full content
+        await self.event_bus.emit(
+            EventType.WORLD_STATE_UPDATED,
+            data={
+                "turn": state.turn,
+                "world_state": parsed.get('updated_state', ''),
+                "key_changes": parsed.get('key_changes', []),
+                "consequences": parsed.get('consequences', []),
+                "tokens_used": llm_response.tokens_used,
+                "cost": cost_amount,
+            },
+            source="world_update_phase",
+        )
 
         # Phase 3.3: Extract metrics from world state
         if self.metrics_tracker:

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -43,6 +43,16 @@ function App() {
         if (event.type === 'turn_completed' && event.data.state) {
           updateStatusFromState(event.data.state)
         }
+
+        // Update turn number from turn_started/turn_completed events
+        if ((event.type === 'turn_started' || event.type === 'turn_completed') && event.data.turn !== undefined) {
+          setStatus(prev => prev ? { ...prev, current_turn: event.data.turn! } : prev)
+        }
+
+        // Update cost from cost events
+        if (event.data.cost !== undefined && event.data.cost > 0) {
+          setStatus(prev => prev ? { ...prev, total_cost: prev.total_cost + event.data.cost! } : prev)
+        }
       })
 
       websocket.onerror = (event) => {

--- a/web/frontend/src/components/ScenarioDashboard.tsx
+++ b/web/frontend/src/components/ScenarioDashboard.tsx
@@ -1,27 +1,112 @@
-import { ScenarioStatus, WebSocketMessage } from '../types'
+import { useState, useEffect } from 'react'
+import { ScenarioStatus, WebSocketMessage, ActivityItem } from '../types'
 
 interface Props {
   status: ScenarioStatus
   wsMessage: WebSocketMessage | null
 }
 
+// Max number of activity items to keep
+const MAX_ACTIVITY_ITEMS = 50
+
 export default function ScenarioDashboard({ status, wsMessage }: Props) {
-  const getActorStatusColor = (actor: { status: string }) => {
-    switch (actor.status) {
+  const [activityFeed, setActivityFeed] = useState<ActivityItem[]>([])
+  const [activeActors, setActiveActors] = useState<Map<string, string>>(new Map())
+  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set())
+
+  // Process incoming WebSocket messages
+  useEffect(() => {
+    if (!wsMessage) return
+
+    // Create activity item from WebSocket message
+    const activityItem = createActivityItem(wsMessage)
+    if (activityItem) {
+      setActivityFeed(prev => {
+        const updated = [activityItem, ...prev].slice(0, MAX_ACTIVITY_ITEMS)
+        return updated
+      })
+    }
+
+    // Update active actors based on event type
+    updateActiveActors(wsMessage)
+  }, [wsMessage])
+
+  const updateActiveActors = (message: WebSocketMessage) => {
+    const { type, data } = message
+
+    if (type === 'actor_decision_started' && data.actor) {
+      setActiveActors(prev => {
+        const updated = new Map(prev)
+        updated.set(data.actor!, 'thinking')
+        return updated
+      })
+    } else if (type === 'actor_decision_completed' && data.actor) {
+      setActiveActors(prev => {
+        const updated = new Map(prev)
+        updated.set(data.actor!, 'complete')
+        return updated
+      })
+    } else if (type === 'turn_started') {
+      // Clear all actor statuses at start of turn
+      setActiveActors(new Map())
+    }
+  }
+
+  const toggleExpanded = (id: string) => {
+    setExpandedItems(prev => {
+      const updated = new Set(prev)
+      if (updated.has(id)) {
+        updated.delete(id)
+      } else {
+        updated.add(id)
+      }
+      return updated
+    })
+  }
+
+  const getActorStatusColor = (actorStatus: string) => {
+    switch (actorStatus) {
       case 'thinking':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'bg-yellow-100 text-yellow-800 animate-pulse'
       case 'complete':
         return 'bg-green-100 text-green-800'
-      case 'your_turn':
-        return 'bg-blue-100 text-blue-800'
       default:
         return 'bg-gray-100 text-gray-800'
     }
   }
 
+  const getEventIcon = (type: string) => {
+    switch (type) {
+      case 'actor_decision_started':
+        return '🤔'
+      case 'actor_decision_completed':
+        return '✅'
+      case 'world_state_updated':
+        return '🌍'
+      case 'communication_sent':
+        return '💬'
+      case 'turn_started':
+        return '▶️'
+      case 'turn_completed':
+        return '✔️'
+      case 'phase_started':
+        return '⚙️'
+      case 'phase_completed':
+        return '✓'
+      default:
+        return '📌'
+    }
+  }
+
+  // Get all unique actors from config and active states
+  const allActors = Array.from(new Set([
+    ...status.actors.map(a => a.name),
+    ...Array.from(activeActors.keys())
+  ]))
+
   return (
     <div className="space-y-6">
-      {/* Turn Progress */}
+      {/* Turn Progress and Cost */}
       <div className="bg-white overflow-hidden shadow rounded-lg">
         <div className="px-4 py-5 sm:p-6">
           <div className="flex items-center justify-between">
@@ -56,130 +141,292 @@ export default function ScenarioDashboard({ status, wsMessage }: Props) {
         </div>
       </div>
 
-      {/* Actor Status Grid */}
+      {/* Active Actors Grid */}
+      {allActors.length > 0 && (
+        <div className="bg-white overflow-hidden shadow rounded-lg">
+          <div className="px-4 py-5 sm:p-6">
+            <h3 className="text-lg font-medium text-gray-900 mb-4">Actor Status</h3>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {allActors.map((actorName, idx) => {
+                const actorStatus = activeActors.get(actorName) || 'idle'
+                const configActor = status.actors.find(a => a.name === actorName)
+
+                return (
+                  <div
+                    key={idx}
+                    className={`relative rounded-lg border border-gray-300 px-4 py-3 ${
+                      actorStatus === 'thinking' ? 'ring-2 ring-yellow-500' : ''
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium text-gray-900 truncate">
+                          {actorName}
+                        </p>
+                        <p className="text-sm text-gray-500">
+                          {configActor?.control === 'human' ? '👤 Human' : '🤖 AI'}
+                        </p>
+                      </div>
+                      <div>
+                        <span
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getActorStatusColor(actorStatus)}`}
+                        >
+                          {actorStatus === 'thinking' ? 'Thinking...' : actorStatus}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Real-Time Activity Feed */}
       <div className="bg-white overflow-hidden shadow rounded-lg">
         <div className="px-4 py-5 sm:p-6">
-          <h3 className="text-lg font-medium text-gray-900 mb-4">Actor Status</h3>
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {status.actors.map((actor, idx) => (
-              <div
-                key={idx}
-                className={`relative rounded-lg border border-gray-300 px-4 py-3 ${
-                  status.waiting_for_actor === actor.name ? 'ring-2 ring-blue-500' : ''
-                }`}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 truncate">
-                      {actor.name}
-                    </p>
-                    <p className="text-sm text-gray-500">
-                      {actor.control === 'human' ? '👤 Human' : '🤖 AI'}
-                    </p>
-                  </div>
-                  <div>
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getActorStatusColor(
-                        actor
-                      )}`}
-                    >
-                      {actor.status}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            ))}
+          <h3 className="text-lg font-medium text-gray-900 mb-4">
+            Live Activity Feed
+            {activityFeed.length > 0 && (
+              <span className="ml-2 text-sm text-gray-500">
+                ({activityFeed.length} events)
+              </span>
+            )}
+          </h3>
+
+          {activityFeed.length === 0 ? (
+            <p className="text-gray-500 text-sm">Waiting for events...</p>
+          ) : (
+            <div className="space-y-4 max-h-[600px] overflow-y-auto">
+              {activityFeed.map((item) => (
+                <ActivityItemCard
+                  key={item.id}
+                  item={item}
+                  isExpanded={expandedItems.has(item.id)}
+                  onToggle={() => toggleExpanded(item.id)}
+                  getEventIcon={getEventIcon}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface ActivityItemCardProps {
+  item: ActivityItem
+  isExpanded: boolean
+  onToggle: () => void
+  getEventIcon: (type: string) => string
+}
+
+function ActivityItemCard({ item, isExpanded, onToggle, getEventIcon }: ActivityItemCardProps) {
+  const hasContent = item.action || item.reasoning || item.world_state || item.content
+
+  return (
+    <div className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50">
+      <div
+        className={`flex items-start space-x-3 ${hasContent ? 'cursor-pointer' : ''}`}
+        onClick={hasContent ? onToggle : undefined}
+      >
+        <span className="text-xl">{getEventIcon(item.type)}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-gray-900">
+              {getActivityTitle(item)}
+            </p>
+            <div className="flex items-center space-x-2">
+              {item.turn !== undefined && (
+                <span className="text-xs text-gray-500">Turn {item.turn}</span>
+              )}
+              <time className="text-xs text-gray-500">
+                {formatTimestamp(item.timestamp)}
+              </time>
+              {hasContent && (
+                <svg
+                  className={`h-4 w-4 text-gray-400 transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              )}
+            </div>
           </div>
+
+          {/* Preview when collapsed */}
+          {!isExpanded && hasContent && (
+            <p className="mt-1 text-sm text-gray-500 truncate">
+              {getPreviewText(item)}
+            </p>
+          )}
         </div>
       </div>
 
-      {/* Recent Activity Feed */}
-      {wsMessage && (
-        <div className="bg-white overflow-hidden shadow rounded-lg">
-          <div className="px-4 py-5 sm:p-6">
-            <h3 className="text-lg font-medium text-gray-900 mb-4">Recent Activity</h3>
-            <div className="flow-root">
-              <div className="-mb-8">
-                <div className="relative pb-8">
-                  <div className="relative flex space-x-3">
-                    <div>
-                      <span className="h-8 w-8 rounded-full bg-blue-500 flex items-center justify-center ring-8 ring-white">
-                        <svg className="h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
-                          <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clipRule="evenodd" />
-                        </svg>
-                      </span>
-                    </div>
-                    <div className="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5">
-                      <div>
-                        <p className="text-sm text-gray-500">
-                          {getEventDescription(wsMessage)}
-                        </p>
-                        {wsMessage.data?.actor && (
-                          <p className="mt-1 text-sm text-gray-900">
-                            Actor: <span className="font-medium">{wsMessage.data.actor}</span>
-                          </p>
-                        )}
-                      </div>
-                      <div className="whitespace-nowrap text-right text-sm text-gray-500">
-                        <time>Just now</time>
-                      </div>
-                    </div>
-                  </div>
-                </div>
+      {/* Expanded content */}
+      {isExpanded && hasContent && (
+        <div className="mt-4 ml-9 space-y-3">
+          {/* Actor Decision Content */}
+          {item.goals && item.goals.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Goals</h4>
+              <ul className="mt-1 text-sm text-gray-600 list-disc list-inside">
+                {item.goals.map((goal, idx) => (
+                  <li key={idx}>{goal}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {item.reasoning && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Reasoning</h4>
+              <div className="mt-1 text-sm text-gray-600 whitespace-pre-wrap max-h-48 overflow-y-auto bg-gray-50 p-3 rounded">
+                {item.reasoning}
               </div>
             </div>
-          </div>
+          )}
+
+          {item.action && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Action</h4>
+              <div className="mt-1 text-sm text-gray-600 whitespace-pre-wrap max-h-48 overflow-y-auto bg-blue-50 p-3 rounded border-l-4 border-blue-400">
+                {item.action}
+              </div>
+            </div>
+          )}
+
+          {/* World State Content */}
+          {item.world_state && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">World State</h4>
+              <div className="mt-1 text-sm text-gray-600 whitespace-pre-wrap max-h-64 overflow-y-auto bg-green-50 p-3 rounded border-l-4 border-green-400">
+                {item.world_state}
+              </div>
+            </div>
+          )}
+
+          {item.key_changes && item.key_changes.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Key Changes</h4>
+              <ul className="mt-1 text-sm text-gray-600 list-disc list-inside">
+                {item.key_changes.map((change, idx) => (
+                  <li key={idx}>{change}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Communication Content */}
+          {item.content && item.type === 'communication_sent' && (
+            <div>
+              <h4 className="text-xs font-semibold text-gray-700 uppercase tracking-wide">
+                Message from {item.sender} to {item.recipients?.join(', ') || 'all'}
+              </h4>
+              <div className="mt-1 text-sm text-gray-600 whitespace-pre-wrap max-h-48 overflow-y-auto bg-purple-50 p-3 rounded border-l-4 border-purple-400">
+                {item.content}
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>
   )
 }
 
-function getEventDescription(message: WebSocketMessage): string {
-  const { type, data } = message
+function createActivityItem(message: WebSocketMessage): ActivityItem | null {
+  const { type, data, timestamp } = message
 
-  // Handle V2 event types
-  switch (type) {
+  // Only create items for relevant event types
+  const relevantTypes = [
+    'actor_decision_started',
+    'actor_decision_completed',
+    'world_state_updated',
+    'communication_sent',
+    'turn_started',
+    'turn_completed',
+    'phase_started',
+    'phase_completed',
+    'scenario_completed',
+    'scenario_halted',
+    'scenario_failed',
+  ]
+
+  if (!relevantTypes.includes(type)) {
+    return null
+  }
+
+  return {
+    id: `${type}-${timestamp}-${Math.random().toString(36).substr(2, 9)}`,
+    type,
+    timestamp,
+    actor: data.actor,
+    content: data.content,
+    goals: data.goals,
+    reasoning: data.reasoning,
+    action: data.action,
+    world_state: data.world_state,
+    key_changes: data.key_changes,
+    sender: data.sender,
+    recipients: data.recipients,
+    turn: data.turn,
+  }
+}
+
+function getActivityTitle(item: ActivityItem): string {
+  switch (item.type) {
+    case 'actor_decision_started':
+      return `${item.actor} is thinking...`
+    case 'actor_decision_completed':
+      return `${item.actor} made a decision`
+    case 'world_state_updated':
+      return 'World state updated'
+    case 'communication_sent':
+      return `${item.sender} sent a message`
     case 'turn_started':
-      return `Turn ${data.turn} started`
+      return `Turn ${item.turn} started`
     case 'turn_completed':
-      return `Turn ${data.turn} completed`
+      return `Turn ${item.turn} completed`
     case 'phase_started':
-      return `Phase ${data.phase} started`
+      return `Phase started`
     case 'phase_completed':
-      return `Phase ${data.phase} completed`
-    case 'decision_made':
-      return `${data.actor} made a decision`
+      return `Phase completed`
     case 'scenario_completed':
       return 'Scenario completed'
     case 'scenario_halted':
-      return `Scenario halted: ${data.reason || 'unknown reason'}`
+      return 'Scenario halted'
     case 'scenario_failed':
-      return `Scenario failed: ${data.error || 'unknown error'}`
-    case 'scenario_finished':
-      return `Scenario finished with status: ${data.status}`
-
-    // Legacy V1.5 event types (for compatibility)
-    case 'turn_start':
-      return `Turn ${data.turn} started`
-    case 'turn_complete':
-      return `Turn ${data.turn} completed`
-    case 'waiting_for_human':
-      return `Waiting for ${data.actor} to make a decision`
-    case 'human_decision_processed':
-      return `Decision from ${data.actor} processed`
-    case 'actor_thinking':
-      return `${data.actor} is thinking...`
-    case 'actor_complete':
-      return `${data.actor} completed their decision`
-    case 'scenario_stopped':
-      return 'Scenario stopped by user'
-    case 'timeout':
-      return 'Decision timeout'
-    case 'error':
-      return `Error: ${data.error || 'unknown error'}`
-
+      return 'Scenario failed'
     default:
-      return `Event: ${type}`
+      return `Event: ${item.type}`
+  }
+}
+
+function getPreviewText(item: ActivityItem): string {
+  if (item.action) {
+    return item.action.substring(0, 150) + (item.action.length > 150 ? '...' : '')
+  }
+  if (item.world_state) {
+    return item.world_state.substring(0, 150) + (item.world_state.length > 150 ? '...' : '')
+  }
+  if (item.content) {
+    return item.content.substring(0, 150) + (item.content.length > 150 ? '...' : '')
+  }
+  if (item.reasoning) {
+    return item.reasoning.substring(0, 150) + (item.reasoning.length > 150 ? '...' : '')
+  }
+  return ''
+}
+
+function formatTimestamp(timestamp: string): string {
+  try {
+    const date = new Date(timestamp)
+    return date.toLocaleTimeString()
+  } catch {
+    return timestamp
   }
 }

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -42,13 +42,45 @@ export interface WebSocketMessage {
     turn?: number
     state?: any
     actor?: string
+    actor_short_name?: string
     phase?: string
     reason?: string
     error?: string
+    model?: string
+    goals?: string[]
+    reasoning?: string
+    action?: string
+    world_state?: string
+    key_changes?: string[]
+    consequences?: string[]
+    content?: string
+    sender?: string
+    recipients?: string[]
+    tokens_used?: number
+    cost?: number
     [key: string]: any
   }
   timestamp: string
   source?: string
+}
+
+/**
+ * Activity item for the activity feed
+ */
+export interface ActivityItem {
+  id: string
+  type: string
+  timestamp: string
+  actor?: string
+  content?: string
+  goals?: string[]
+  reasoning?: string
+  action?: string
+  world_state?: string
+  key_changes?: string[]
+  sender?: string
+  recipients?: string[]
+  turn?: number
 }
 
 /**


### PR DESCRIPTION
- Add ACTOR_DECISION_STARTED/COMPLETED events to DecisionPhaseV2 with full content (goals, reasoning, action)
- Add WORLD_STATE_UPDATED event to WorldUpdatePhaseV2 with full world state content and key changes
- Add COMMUNICATION_SENT event to CommunicationPhase with full message content
- Pass event_bus to all phase services from sync_runner
- Reduce WebSocket polling delay from 500ms to 100ms for faster updates
- Enhance frontend ScenarioDashboard with:
  - Live activity feed showing last 50 events
  - Expandable event cards with full content excerpts
  - Real-time actor status tracking (thinking/complete)
  - Color-coded content sections for decisions, world states, communications
- Update App.tsx to track turn and cost updates from events
- Add ActivityItem type for typed activity feed items