### PR TITLE
Fix #55: Add deferred annotation import to prevent NameError when ric…

### DIFF
--- a/scenario_lab/batch/batch_progress_tracker.py
+++ b/scenario_lab/batch/batch_progress_tracker.py
@@ -12,6 +12,8 @@ V2 Design:
 - Graceful degradation without rich library
 - Works with V2 batch components
 """
+from __future__ import annotations
+
 import time
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any


### PR DESCRIPTION
…h is missing

The `_generate_display` method had a return type annotation `-> Layout` that would cause a NameError when the rich library wasn't installed, since the Layout import was inside a try/except block. By adding `from __future__ import annotations`, type annotations are now evaluated lazily, preventing the error.