### PR TITLE
Fix issue 101

### DIFF
--- a/scenario_lab/core/world_synthesizer.py
+++ b/scenario_lab/core/world_synthesizer.py
@@ -82,7 +82,8 @@ Do NOT skip any sections. Do NOT merge sections together."""
         turn: int,
         total_turns: int,
         actor_decisions: Dict[str, Dict[str, str]],
-        exogenous_events: Optional[List[Dict[str, str]]] = None
+        exogenous_events: Optional[List[Dict[str, str]]] = None,
+        turn_duration: Optional[str] = None
     ) -> str:
         """
         Build user prompt with current state and actor decisions
@@ -93,6 +94,7 @@ Do NOT skip any sections. Do NOT merge sections together."""
             total_turns: Total number of turns
             actor_decisions: Dict of {actor_name: {action, reasoning}} for this turn
             exogenous_events: Optional list of background events (Phase 1.3: stub)
+            turn_duration: How long each turn represents (e.g., "6 months", "1 week")
 
         Returns:
             User prompt string
@@ -112,8 +114,13 @@ Do NOT skip any sections. Do NOT merge sections together."""
                 events_text += f"**{event.get('name', 'Event')}:** {event.get('description', '')}\n\n"
             events_text += "---\n\n"
 
-        prompt = f"""## Current World State (Turn {turn} of {total_turns})
+        # Build temporal context
+        temporal_context = ""
+        if turn_duration:
+            temporal_context = f"\n**Time Progression:** Each turn represents {turn_duration}. Ensure that time references in the world state reflect this progression (e.g., if Turn 1 starts in January 2026 and each turn is 6 months, Turn 2 should reflect July 2026).\n"
 
+        prompt = f"""## Current World State (Turn {turn} of {total_turns})
+{temporal_context}
 {current_state}
 
 ---

--- a/scenario_lab/services/world_update_phase_v2.py
+++ b/scenario_lab/services/world_update_phase_v2.py
@@ -107,6 +107,9 @@ class WorldUpdatePhaseV2:
         # Get exogenous events from state metadata (set by orchestrator)
         exogenous_events = state.metadata.get("exogenous_events", None)
 
+        # Get turn_duration from scenario config
+        turn_duration = state.scenario_config.get("turn_duration")
+
         # Build prompts using synthesizer
         system_prompt = self.synthesizer.build_system_prompt()
         user_prompt = self.synthesizer.build_user_prompt(
@@ -114,7 +117,8 @@ class WorldUpdatePhaseV2:
             turn=state.turn,
             total_turns=total_turns,
             actor_decisions=actor_decisions_for_update,
-            exogenous_events=exogenous_events
+            exogenous_events=exogenous_events,
+            turn_duration=turn_duration
         )
 
         # Build messages for LLM


### PR DESCRIPTION
The turn_duration configuration field was validated and loaded from scenario.yaml but not passed to the LLM when generating world state updates, causing the LLM to guess at time progression instead of using the configured duration.

Changes:
- Add turn_duration parameter to WorldSynthesizer.build_user_prompt()
- Include temporal context in world synthesis prompt when turn_duration is configured (e.g., "Each turn represents 6 months")
- Pass turn_duration from scenario config in WorldUpdatePhaseV2

Fixes #101