### PR TITLE
Fix issue 102

### DIFF
--- a/scenario_lab/core/events.py
+++ b/scenario_lab/core/events.py
@@ -66,6 +66,9 @@ class EventType(str, Enum):
     VALIDATION_COMPLETED = "validation_completed"
     VALIDATION_FAILED = "validation_failed"
 
+    # Exogenous events
+    EXOGENOUS_EVENT_TRIGGERED = "exogenous_event_triggered"
+
     # Persistence events
     STATE_SAVED = "state_saved"
     STATE_LOADED = "state_loaded"

--- a/scenario_lab/core/orchestrator.py
+++ b/scenario_lab/core/orchestrator.py
@@ -291,6 +291,19 @@ class ScenarioOrchestrator:
                     new_metadata = {**state.metadata, "exogenous_events": events_for_world_update}
                     state = replace(state, metadata=new_metadata)
 
+                    # Emit event for each triggered exogenous event
+                    for evt in triggered_events:
+                        await self.event_bus.emit(
+                            EventType.EXOGENOUS_EVENT_TRIGGERED,
+                            data={
+                                "turn": turn,
+                                "name": evt.name,
+                                "description": evt.description,
+                                "event_type": getattr(evt, "event_type", "unknown"),
+                            },
+                            source="orchestrator",
+                        )
+
                 # Update triggered event IDs in state
                 state = state.with_triggered_events(
                     self.exogenous_event_manager.get_triggered_event_ids()

--- a/scenario_lab/interfaces/cli.py
+++ b/scenario_lab/interfaces/cli.py
@@ -142,11 +142,17 @@ def run(
             reason = event.data.get("reason", "unknown")
             print_warning(f"Scenario halted: {reason}")
 
+        async def on_exogenous_event(event: Event):
+            name = event.data.get("name", "unknown")
+            event_type = event.data.get("event_type", "unknown")
+            console.print(f"  [yellow]\u26a1[/] Exogenous event triggered: [cyan]'{name}'[/] ({event_type})")
+
         # Register handlers
         event_bus.on(EventType.TURN_STARTED, on_turn_start)
         event_bus.on(EventType.PHASE_COMPLETED, on_phase_complete)
         event_bus.on(EventType.CREDIT_LIMIT_WARNING, on_credit_warning)
         event_bus.on(EventType.SCENARIO_HALTED, on_halted)
+        event_bus.on(EventType.EXOGENOUS_EVENT_TRIGGERED, on_exogenous_event)
 
         # Run scenario
         print_section("Running scenario...")


### PR DESCRIPTION
When exogenous events (random, scheduled, conditional) fire during scenario execution, the CLI now displays feedback with the event name and type. This improves debugging and verification of event activation.

Fixes #102