### PR TITLE
Fix issue 199

### DIFF
--- a/prompts/system/events.md
+++ b/prompts/system/events.md
@@ -23,6 +23,8 @@ En viktig del av beskrivningen av världen är dessa metrics, som varierar inom 
 
 Till scenariot hör ett antal externa händelser, som kan hända om givna villkor är uppfyllda. Din uppgift just nu är att gå igenom listan med möjliga externa händelser, och för varje händelse utvärdera om dess villkor är uppfyllt utifrån nuvarande världsläge. Om sannolikheten anges som en formel eller beskrivning (t.ex. "dubbla värdet på unemployment"), ska du beräkna det faktiska värdet.
 
+Du har också tillgång till ett anteckningsblock (Notepad) där du kan spara information som är viktig att komma ihåg mellan rundor, men som inte passar i metrics eller narrativen. Detta kan till exempel vara pågående händelser som påverkar villkor för framtida händelser.
+
 Ditt svar ska vara en JSON-array med objekt för varje händelse vars villkor är uppfyllt, på det här formatet:
 
 ```json

--- a/prompts/system/metric-rules.md
+++ b/prompts/system/metric-rules.md
@@ -23,6 +23,8 @@ En viktig del av beskrivningen av världen är dessa metrics, som varierar inom 
 
 Det finns en lista, Metrics Rules, som beskriver hur metrics förändras baserat på tid eller värden på andra metrics. Din uppgift just nu är att, utifrån nuvarande världsläge och de handlingar som aktörer gjort, uppdatera Metrics Rules.
 
+Du har också tillgång till ett anteckningsblock (Notepad) där du kan se viktig information som sparats mellan rundor.
+
 **Viktigt:** Varje regel MÅSTE beskriva hur en eller flera metrics förändras baserat på:
 - Tiden/omvärlden (exempelvis "ai_capability dubbleras varje halvår")
 - Värden på andra metrics (exempelvis "När unemployment > 15 minskar public_sentiment_to_ai med 1 per runda")

--- a/prompts/system/metrics-update.md
+++ b/prompts/system/metrics-update.md
@@ -21,11 +21,12 @@ En viktig del av beskrivningen av världen är dessa metrics, som varierar inom 
 * Namn på metric 2
   * …
 
-Det finns en lista, Metrics Rules, som beskriver hur metrics eventuellt påverkar varandra eller utvecklas över tid. Din uppgift just nu är att göra tre saker:
+Det finns en lista, Metrics Rules, som beskriver hur metrics eventuellt påverkar varandra eller utvecklas över tid. Din uppgift just nu är att göra fyra saker:
 
 * Avgöra hur framgångsrika aktörerna är med sina handlingar. Detta baseras hur världen ser ut samt din bedömning av hur sannolikt det är att de lyckas.
 * Utgå från aktörernas handlingar och Metric Rules för att bestämma Metrics inför nästa runda.
 * Skriva en sammanhängande berättelse som berättar vad som händer i världen under den här rundan.
+* Uppdatera anteckningsblocket (Notepad) med viktig information som bör kommas ihåg till nästa runda, men som inte passar i metrics eller narrativen. Detta kan vara pågående händelser, villkor som trätt i kraft, eller annan information som påverkar framtida rundor. Om inget behöver antecknas, lämna anteckningsblocket tomt.
 
 Svara med en Markdown-text med följande innehåll:
 
@@ -33,6 +34,8 @@ Svara med en Markdown-text med följande innehåll:
 * Ett JSON-objekt som beskriver samtliga metrics, i följande format: `{"metric1_name": value1, "metric2_name": value2}`
 * Rubrik nivå 2: Narrativ
 * En sammanhängande berättelse om vad som händer i världen under rundan (max 400 ord). Du kan använda underrubriker (nivå 3) om du önskar.
+* Rubrik nivå 2: Notepad
+* Valfritt anteckningsblock med viktig information att komma ihåg till nästa runda. Lämna tomt om inget behöver antecknas.
 
 ### Prompt för Game Master (ändras mellan varje runda)
 

--- a/scenario_lab/llm.py
+++ b/scenario_lab/llm.py
@@ -56,8 +56,8 @@ class LLMResponse:
             return data
         raise ValueError(f"Expected JSON array, got {type(data)}")
 
-    def extract_metrics_and_narrative(self) -> tuple[dict, str]:
-        """Extract metrics JSON and narrative from metrics update response.
+    def extract_metrics_and_narrative(self) -> tuple[dict, str, str]:
+        """Extract metrics JSON, narrative, and notepad from metrics update response.
 
         Expected format:
         ## Metrics
@@ -67,6 +67,9 @@ class LLMResponse:
 
         ## Narrativ
         narrative text...
+
+        ## Notepad
+        notepad text...
         """
         # Find ## Metrics section with JSON
         metrics_match = re.search(
@@ -83,14 +86,21 @@ class LLMResponse:
 
         metrics = json.loads(metrics_match.group(1))
 
-        # Find ## Narrativ section
+        # Find ## Narrativ section (stop at ## Notepad if present)
         narrative_match = re.search(
-            r"##\s*Narrativ\s*\n+(.*)", self.content, re.DOTALL | re.IGNORECASE
+            r"##\s*Narrativ\s*\n+(.*?)(?=##\s*Notepad|\Z)", self.content, re.DOTALL | re.IGNORECASE
         )
 
         narrative = narrative_match.group(1).strip() if narrative_match else ""
 
-        return metrics, narrative
+        # Find ## Notepad section (optional)
+        notepad_match = re.search(
+            r"##\s*Notepad\s*\n+(.*)", self.content, re.DOTALL | re.IGNORECASE
+        )
+
+        notepad = notepad_match.group(1).strip() if notepad_match else ""
+
+        return metrics, narrative, notepad
 
 
 class LLMClient:

--- a/scenario_lab/models.py
+++ b/scenario_lab/models.py
@@ -104,6 +104,7 @@ class TurnResult:
     metric_rules: str  # Markdown numbered list
     metrics: dict[str, float]  # metric_id -> value
     narrative: str  # World state narrative
+    notepad: str  # Game Master notes
 
 
 @dataclass
@@ -178,6 +179,7 @@ class Scenario:
     metric_rules: str  # Current rules as markdown
     world_state: WorldState
     context: str  # Background context
+    notepad: str = ""  # Game Master notes that persist across turns
 
     # History
     turn_history: list[TurnResult] = field(default_factory=list)

--- a/scenario_lab/orchestrator.py
+++ b/scenario_lab/orchestrator.py
@@ -204,14 +204,15 @@ class Orchestrator:
 
         # Step 4: Update metrics and generate narrative
         print("\n[4/4] Updating metrics and generating narrative...")
-        new_metrics, narrative = self._run_metrics_step(turn, actor_outputs, triggered_events)
+        new_metrics, narrative, notepad = self._run_metrics_step(turn, actor_outputs, triggered_events)
         print(f"  → Metrics and narrative updated")
         if self.output_manager:
             self.output_manager.save_metrics_and_narrative(turn, new_metrics, narrative)
+            self.output_manager.save_notepad(turn, notepad)
             self.output_manager.update_summary(turn, new_metrics)
 
         # Update scenario state
-        self._update_scenario_state(new_metrics, narrative, turn, time_period)
+        self._update_scenario_state(new_metrics, narrative, notepad, turn, time_period)
 
         # Build and return result
         return TurnResult(
@@ -222,6 +223,7 @@ class Orchestrator:
             metric_rules=new_rules,
             metrics=new_metrics,
             narrative=narrative,
+            notepad=notepad,
         )
 
     def _run_events_step(self, turn: int) -> list[dict]:
@@ -330,7 +332,7 @@ class Orchestrator:
 
     def _run_metrics_step(
         self, turn: int, actor_outputs: dict[str, str], triggered_events: list[dict]
-    ) -> tuple[dict, str]:
+    ) -> tuple[dict, str, str]:
         """Step 4: Update metrics and generate narrative.
 
         Args:
@@ -339,7 +341,7 @@ class Orchestrator:
             triggered_events: List of events that occurred
 
         Returns:
-            Tuple of (metrics dict, narrative string)
+            Tuple of (metrics dict, narrative string, notepad string)
         """
         system, user = self.prompt_builder.build_metrics_prompt(
             turn, actor_outputs, triggered_events
@@ -347,7 +349,7 @@ class Orchestrator:
         response = self.llm_clients["metrics"].complete(system, user)
 
         try:
-            metrics, narrative = response.extract_metrics_and_narrative()
+            metrics, narrative, notepad = response.extract_metrics_and_narrative()
         except (json.JSONDecodeError, ValueError) as e:
             print(f"  Warning: Could not parse metrics response: {e}")
             print(f"  Response was: {response.content[:200]}...")
@@ -358,7 +360,7 @@ class Orchestrator:
                 "[ERROR: Could not parse metrics response. Keeping previous values.]\n\n"
                 + response.content
             )
-            return current_metrics, error_narrative
+            return current_metrics, error_narrative, self.scenario.notepad
 
         # Validate and clamp metrics
         for metric_id, value in list(metrics.items()):
@@ -377,7 +379,7 @@ class Orchestrator:
                 print(f"  Warning: Unknown metric '{metric_id}' in response, skipping")
                 del metrics[metric_id]
 
-        return metrics, narrative
+        return metrics, narrative, notepad
 
     def _mark_event_occurred(self, event_id: str):
         """Mark event as occurred (for non-repeatable events)."""
@@ -387,11 +389,12 @@ class Orchestrator:
                 self.scenario.occurred_events.add(event_id)
 
     def _update_scenario_state(
-        self, new_metrics: dict, narrative: str, turn: int, time_period: str
+        self, new_metrics: dict, narrative: str, notepad: str, turn: int, time_period: str
     ):
         """Update scenario with turn results."""
         self.scenario.metrics.update_from_dict(new_metrics)
         self.scenario.world_state.narrative = narrative
+        self.scenario.notepad = notepad
         self.scenario.world_state.turn = turn
         self.scenario.world_state.time_period = time_period
 

--- a/scenario_lab/output.py
+++ b/scenario_lab/output.py
@@ -101,6 +101,16 @@ class OutputManager:
         )
         (turn_dir / "4-world-state.md").write_text(narrative, encoding="utf-8")
 
+    def save_notepad(self, turn: int, notepad: str):
+        """Save notepad immediately after generation.
+
+        Args:
+            turn: Turn number
+            notepad: Notepad content
+        """
+        turn_dir = self.get_turn_dir(turn)
+        (turn_dir / "5-notepad.md").write_text(notepad, encoding="utf-8")
+
     def save_turn(self, result: TurnResult):
         """Save results from a single turn.
 
@@ -137,6 +147,9 @@ class OutputManager:
 
         # 5. World state narrative
         (turn_dir / "4-world-state.md").write_text(result.narrative, encoding="utf-8")
+
+        # 6. Notepad
+        (turn_dir / "5-notepad.md").write_text(result.notepad, encoding="utf-8")
 
     def update_summary(self, current_turn: int, latest_metrics: dict):
         """Update summary after each turn (incremental).

--- a/scenario_lab/prompts.py
+++ b/scenario_lab/prompts.py
@@ -63,6 +63,17 @@ class PromptBuilder:
         user_parts.append("---")
         user_parts.append("")
 
+        # Add notepad
+        user_parts.append("Anteckningsblocket (Notepad) innehåller följande information:")
+        user_parts.append("")
+        if self.scenario.notepad.strip():
+            user_parts.append(self.scenario.notepad)
+        else:
+            user_parts.append("(Tomt)")
+        user_parts.append("")
+        user_parts.append("---")
+        user_parts.append("")
+
         # Add events list
         user_parts.append("Listan över potentiella externa händelser ser ut så här:")
         user_parts.append("")
@@ -214,7 +225,20 @@ class PromptBuilder:
             "",
             "---",
             "",
+            "Anteckningsblocket (Notepad) innehåller följande information:",
+            "",
         ]
+
+        if self.scenario.notepad.strip():
+            user_parts.append(self.scenario.notepad)
+        else:
+            user_parts.append("(Tomt)")
+
+        user_parts.extend([
+            "",
+            "---",
+            "",
+        ])
 
         # Add triggered events
         user_parts.append("Denna runda har följande externa händelser inträffat:")
@@ -284,7 +308,20 @@ class PromptBuilder:
             "",
             "---",
             "",
+            "Anteckningsblocket (Notepad) innehåller följande information:",
+            "",
         ]
+
+        if self.scenario.notepad.strip():
+            user_parts.append(self.scenario.notepad)
+        else:
+            user_parts.append("(Tomt)")
+
+        user_parts.extend([
+            "",
+            "---",
+            "",
+        ])
 
         # Add triggered events
         user_parts.append("Denna runda har följande externa händelser inträffat:")

--- a/test_orchestrator.py
+++ b/test_orchestrator.py
@@ -35,7 +35,11 @@ Regeringen lanserar ett omfattande AI-stödprogram för små och medelstora för
 
 ## Narrativ
 
-Sverige genomgår en period av intensiv AI-adoption efter regeringens stödprogram. Små och medelstora företag börjar implementera AI-lösningar, vilket driver upp adoptionsgraden. Samtidigt syns tidiga tecken på oro på arbetsmarknaden när vissa rutinjobb automatiseras.""",
+Sverige genomgår en period av intensiv AI-adoption efter regeringens stödprogram. Små och medelstora företag börjar implementera AI-lösningar, vilket driver upp adoptionsgraden. Samtidigt syns tidiga tecken på oro på arbetsmarknaden när vissa rutinjobb automatiseras.
+
+## Notepad
+
+Regeringens AI-stödprogram lanserades under denna runda. Programmet förväntas pågå i minst 2 rundor.""",
 }
 
 mock_llm = MockLLMClient(mock_responses)
@@ -58,3 +62,5 @@ for metric_id, value in result.metrics.items():
     print(f"  {metric_id}: {value}")
 print(f"\nNarrative preview:")
 print(result.narrative[:200] + "...")
+print(f"\nNotepad:")
+print(result.notepad if result.notepad else "(empty)")


### PR DESCRIPTION
…Issue #119)

Implements a persistent notepad feature that allows the Game Master (LLM) to track important information across turns. This addresses use cases like tracking when events occur and their ongoing effects (e.g., "AI slowdown keeps development pace low until AI breakthrough occurs").

Changes:
- Add notepad field to Scenario and TurnResult models
- Update system prompts to introduce notepad capability
- Update user prompts to include current notepad content
- Modify LLM response parsing to extract notepad from metrics step
- Update orchestrator to save notepad state after each turn
- Add save_notepad() method to OutputManager
- Save notepad to 5-notepad.md in turn directories
- Update test_orchestrator.py to include notepad in mock response

The notepad is updated during the metrics step and persists across all turns, allowing the LLM to maintain context that doesn't fit in metrics or narrative.